### PR TITLE
Parametrize Dataset Names and Traces

### DIFF
--- a/dags/export_dag.py
+++ b/dags/export_dag.py
@@ -110,8 +110,11 @@ ethereumetl_repo_branch = os.environ.get('ETHEREUMETL_REPO_BRANCH', 'master')
 dags_folder = os.environ.get('DAGS_FOLDER', '/home/airflow/gcs/dags')
 export_max_workers = os.environ.get('EXPORT_MAX_WORKERS', '5')
 export_batch_size = os.environ.get('EXPORT_BATCH_SIZE', '10')
-export_daofork_traces = os.environ.get('EXPORT_DAOFORK_TRACES', '--daofork-traces')
-export_genesis_traces = os.environ.get('EXPORT_GENESIS_TRACES', '--genesis-traces')
+export_daofork_traces = os.environ.get('EXPORT_DAOFORK_TRACES', True)
+export_genesis_traces = os.environ.get('EXPORT_GENESIS_TRACES', True)
+export_traces_extra_params = '{} {}'.format(
+        '--daofork-traces' if export_daofork_traces else '', 
+        '--genesis-traces' if export_genesis_traces else '')
 
 # ds is 1 day behind the date on which the run is scheduled, e.g. if the dag is scheduled to run at
 # 1am on January 2, ds will be January 1.
@@ -124,8 +127,7 @@ environment = {
     'DAGS_FOLDER': dags_folder,
     'EXPORT_MAX_WORKERS': export_max_workers,
     'EXPORT_BATCH_SIZE': export_batch_size,
-    'EXPORT_DAOFORK_TRACES': export_daofork_traces,
-    'EXPORT_GENESIS_TRACES': export_genesis_traces
+    'EXPORT_TRACES_EXTRA_PARAMS': export_traces_extra_params,
 }
 
 def add_export_task(toggle, task_id, bash_command, dependencies=None):

--- a/dags/export_dag.py
+++ b/dags/export_dag.py
@@ -98,7 +98,7 @@ export_traces_command = \
     setup_command + ' && ' + \
     '$PYTHON3 export_traces.py -b $EXPORT_BATCH_SIZE -w $EXPORT_MAX_WORKERS -s $START_BLOCK -e $END_BLOCK ' \
     '-p $WEB3_PROVIDER_URI_ARCHIVAL -o traces.csv ' \
-    '$EXPORT_TRACE_EXTRA_PARAMS && ' \
+    '$EXPORT_DAOFORK_TRACES $EXPORT_GENESIS_TRACES && ' \
     'gsutil cp traces.csv $EXPORT_LOCATION_URI/traces/block_date=$EXECUTION_DATE/traces.csv '
 
 output_bucket = os.environ.get('OUTPUT_BUCKET')
@@ -110,7 +110,8 @@ ethereumetl_repo_branch = os.environ.get('ETHEREUMETL_REPO_BRANCH', 'master')
 dags_folder = os.environ.get('DAGS_FOLDER', '/home/airflow/gcs/dags')
 export_max_workers = os.environ.get('EXPORT_MAX_WORKERS', '5')
 export_batch_size = os.environ.get('EXPORT_BATCH_SIZE', '10')
-export_trace_extra_params = os.environ.get('EXPORT_TRACE_EXTRA_PARAMS', ['--dao-traces', '--genesis-traces'])
+export_daofork_traces = os.environ.get('EXPORT_DAOFORK_TRACES', '--daofork-traces')
+export_genesis_traces = os.environ.get('EXPORT_GENESIS_TRACES', '--genesis-traces')
 
 # ds is 1 day behind the date on which the run is scheduled, e.g. if the dag is scheduled to run at
 # 1am on January 2, ds will be January 1.
@@ -123,9 +124,9 @@ environment = {
     'DAGS_FOLDER': dags_folder,
     'EXPORT_MAX_WORKERS': export_max_workers,
     'EXPORT_BATCH_SIZE': export_batch_size,
-    'EXPORT_TRACE_EXTRA_PARAMS': export_trace_extra_params
+    'EXPORT_DAOFORK_TRACES': export_daofork_traces,
+    'EXPORT_GENESIS_TRACES': export_genesis_traces
 }
-
 
 def add_export_task(toggle, task_id, bash_command, dependencies=None):
     if toggle:

--- a/dags/export_dag.py
+++ b/dags/export_dag.py
@@ -98,7 +98,7 @@ export_traces_command = \
     setup_command + ' && ' + \
     '$PYTHON3 export_traces.py -b $EXPORT_BATCH_SIZE -w $EXPORT_MAX_WORKERS -s $START_BLOCK -e $END_BLOCK ' \
     '-p $WEB3_PROVIDER_URI_ARCHIVAL -o traces.csv ' \
-    '--genesis-traces --daofork-traces && ' \
+    '$EXPORT_TRACE_EXTRA_PARAMS && ' \
     'gsutil cp traces.csv $EXPORT_LOCATION_URI/traces/block_date=$EXECUTION_DATE/traces.csv '
 
 output_bucket = os.environ.get('OUTPUT_BUCKET')
@@ -110,6 +110,7 @@ ethereumetl_repo_branch = os.environ.get('ETHEREUMETL_REPO_BRANCH', 'master')
 dags_folder = os.environ.get('DAGS_FOLDER', '/home/airflow/gcs/dags')
 export_max_workers = os.environ.get('EXPORT_MAX_WORKERS', '5')
 export_batch_size = os.environ.get('EXPORT_BATCH_SIZE', '10')
+export_trace_extra_params = os.environ.get('EXPORT_TRACE_EXTRA_PARAMS', ['--dao-traces', '--genesis-traces'])
 
 # ds is 1 day behind the date on which the run is scheduled, e.g. if the dag is scheduled to run at
 # 1am on January 2, ds will be January 1.
@@ -121,7 +122,8 @@ environment = {
     'OUTPUT_BUCKET': output_bucket,
     'DAGS_FOLDER': dags_folder,
     'EXPORT_MAX_WORKERS': export_max_workers,
-    'EXPORT_BATCH_SIZE': export_batch_size
+    'EXPORT_BATCH_SIZE': export_batch_size,
+    'EXPORT_TRACE_EXTRA_PARAMS': export_trace_extra_params
 }
 
 

--- a/dags/load_dag.py
+++ b/dags/load_dag.py
@@ -57,7 +57,7 @@ def read_file(filepath):
     with open(filepath) as file_handle:
         content = file_handle.read()
         for key, value in environment.items():
-            content.replace(f'{{{key}}}', value)
+            content.replace('{{{key}}}'.format(key=key), value)
         return content
 
 
@@ -126,7 +126,7 @@ def add_load_tasks(task, file_format, allow_quoted_newlines=False):
         export_location_uri = 'gs://{bucket}/export'.format(bucket=output_bucket)
         uri = '{export_location_uri}/{task}/*.{file_format}'.format(
             export_location_uri=export_location_uri, task=task, file_format=file_format)
-        table_ref = client.dataset(f'{dataset_name}_raw').table(task)
+        table_ref = client.dataset(dataset_name_raw).table(task)
         load_job = client.load_table_from_uri(uri, table_ref, job_config=job_config)
         submit_bigquery_job(load_job, job_config)
         assert load_job.state == 'DONE'

--- a/dags/load_dag.py
+++ b/dags/load_dag.py
@@ -36,13 +36,13 @@ sql_files = [
     'resources/stages/verify/sqls/token_transfers_have_latest.sql',
     'resources/stages/verify/sqls/traces_blocks_count.sql',
     'resources/stages/verify/sqls/transactions_count.sql',
-    'resources/stages/enrich/sqls/token_transfers.sql'
-    'resources/stages/enrich/sqls/contracts.sql'
-    'resources/stages/enrich/sqls/blocks.sql'
-    'resources/stages/enrich/sqls/traces.sql'
-    'resources/stages/enrich/sqls/transactions.sql'
-    'resources/stages/enrich/sqls/blocks_count.sql'
-    'resources/stages/enrich/sqls/tokens.sql'
+    'resources/stages/verify/sqls/blocks_count.sql',
+    'resources/stages/enrich/sqls/token_transfers.sql',
+    'resources/stages/enrich/sqls/contracts.sql',
+    'resources/stages/enrich/sqls/blocks.sql',
+    'resources/stages/enrich/sqls/traces.sql',
+    'resources/stages/enrich/sqls/transactions.sql',
+    'resources/stages/enrich/sqls/tokens.sql',
     'resources/stages/enrich/sqls/logs.sql'
 ]
 

--- a/dags/resources/stages/enrich/sqls/blocks.sql
+++ b/dags/resources/stages/enrich/sqls/blocks.sql
@@ -17,4 +17,4 @@ SELECT
     blocks.gas_limit,
     blocks.gas_used,
     blocks.transaction_count
-FROM ethereum_blockchain_raw.blocks AS blocks
+FROM blockchain_raw.blocks AS blocks

--- a/dags/resources/stages/enrich/sqls/blocks.sql
+++ b/dags/resources/stages/enrich/sqls/blocks.sql
@@ -17,4 +17,4 @@ SELECT
     blocks.gas_limit,
     blocks.gas_used,
     blocks.transaction_count
-FROM blockchain_raw.blocks AS blocks
+FROM {{DATASET_NAME_RAW}}.blocks AS blocks

--- a/dags/resources/stages/enrich/sqls/contracts.sql
+++ b/dags/resources/stages/enrich/sqls/contracts.sql
@@ -7,6 +7,6 @@ SELECT
     TIMESTAMP_SECONDS(blocks.timestamp) AS block_timestamp,
     blocks.number AS block_number,
     blocks.hash AS block_hash
-FROM ethereum_blockchain_raw.contracts AS contracts
-    JOIN ethereum_blockchain_raw.receipts AS receipts ON receipts.contract_address = contracts.address
-    JOIN ethereum_blockchain_raw.blocks AS blocks ON blocks.number = receipts.block_number
+FROM blockchain_raw.contracts AS contracts
+    JOIN blockchain_raw.receipts AS receipts ON receipts.contract_address = contracts.address
+    JOIN blockchain_raw.blocks AS blocks ON blocks.number = receipts.block_number

--- a/dags/resources/stages/enrich/sqls/contracts.sql
+++ b/dags/resources/stages/enrich/sqls/contracts.sql
@@ -7,6 +7,6 @@ SELECT
     TIMESTAMP_SECONDS(blocks.timestamp) AS block_timestamp,
     blocks.number AS block_number,
     blocks.hash AS block_hash
-FROM blockchain_raw.contracts AS contracts
-    JOIN blockchain_raw.receipts AS receipts ON receipts.contract_address = contracts.address
-    JOIN blockchain_raw.blocks AS blocks ON blocks.number = receipts.block_number
+FROM {{DATASET_NAME_RAW}}.contracts AS contracts
+    JOIN {{DATASET_NAME_RAW}}.receipts AS receipts ON receipts.contract_address = contracts.address
+    JOIN {{DATASET_NAME_RAW}}.blocks AS blocks ON blocks.number = receipts.block_number

--- a/dags/resources/stages/enrich/sqls/logs.sql
+++ b/dags/resources/stages/enrich/sqls/logs.sql
@@ -8,5 +8,5 @@ SELECT
     TIMESTAMP_SECONDS(blocks.timestamp) AS block_timestamp,
     blocks.number AS block_number,
     blocks.hash AS block_hash
-FROM blockchain_raw.blocks AS blocks
-    JOIN blockchain_raw.logs AS logs ON blocks.number = logs.block_number
+FROM {{DATASET_NAME_RAW}}.blocks AS blocks
+    JOIN {{DATASET_NAME_RAW}}.logs AS logs ON blocks.number = logs.block_number

--- a/dags/resources/stages/enrich/sqls/logs.sql
+++ b/dags/resources/stages/enrich/sqls/logs.sql
@@ -8,5 +8,5 @@ SELECT
     TIMESTAMP_SECONDS(blocks.timestamp) AS block_timestamp,
     blocks.number AS block_number,
     blocks.hash AS block_hash
-FROM ethereum_blockchain_raw.blocks AS blocks
-    JOIN ethereum_blockchain_raw.logs AS logs ON blocks.number = logs.block_number
+FROM blockchain_raw.blocks AS blocks
+    JOIN blockchain_raw.logs AS logs ON blocks.number = logs.block_number

--- a/dags/resources/stages/enrich/sqls/token_transfers.sql
+++ b/dags/resources/stages/enrich/sqls/token_transfers.sql
@@ -8,5 +8,5 @@ SELECT
     TIMESTAMP_SECONDS(blocks.timestamp) AS block_timestamp,
     blocks.number AS block_number,
     blocks.hash AS block_hash
-FROM blockchain_raw.blocks AS blocks
-    JOIN blockchain_raw.token_transfers AS token_transfers ON blocks.number = token_transfers.block_number
+FROM {{DATASET_NAME_RAW}}.blocks AS blocks
+    JOIN {{DATASET_NAME_RAW}}.token_transfers AS token_transfers ON blocks.number = token_transfers.block_number

--- a/dags/resources/stages/enrich/sqls/token_transfers.sql
+++ b/dags/resources/stages/enrich/sqls/token_transfers.sql
@@ -8,5 +8,5 @@ SELECT
     TIMESTAMP_SECONDS(blocks.timestamp) AS block_timestamp,
     blocks.number AS block_number,
     blocks.hash AS block_hash
-FROM ethereum_blockchain_raw.blocks AS blocks
-    JOIN ethereum_blockchain_raw.token_transfers AS token_transfers ON blocks.number = token_transfers.block_number
+FROM blockchain_raw.blocks AS blocks
+    JOIN blockchain_raw.token_transfers AS token_transfers ON blocks.number = token_transfers.block_number

--- a/dags/resources/stages/enrich/sqls/tokens.sql
+++ b/dags/resources/stages/enrich/sqls/tokens.sql
@@ -7,7 +7,7 @@ WITH tokens_grouped AS (
         total_supply,
         ROW_NUMBER() OVER (PARTITION BY address) AS rank
     FROM
-        ethereum_blockchain_raw.tokens)
+        blockchain_raw.tokens)
 SELECT
     address,
     symbol,

--- a/dags/resources/stages/enrich/sqls/tokens.sql
+++ b/dags/resources/stages/enrich/sqls/tokens.sql
@@ -7,7 +7,7 @@ WITH tokens_grouped AS (
         total_supply,
         ROW_NUMBER() OVER (PARTITION BY address) AS rank
     FROM
-        blockchain_raw.tokens)
+        {{DATASET_NAME_RAW}}.tokens)
 SELECT
     address,
     symbol,

--- a/dags/resources/stages/enrich/sqls/traces.sql
+++ b/dags/resources/stages/enrich/sqls/traces.sql
@@ -2,15 +2,15 @@ WITH traces_with_status AS (
     -- Find all nested traces of failed traces
     WITH nested_failed_traces AS (
         SELECT distinct child.transaction_hash, child.trace_address
-        FROM ethereum_blockchain_raw.traces parent
-        JOIN ethereum_blockchain_raw.traces child
+        FROM blockchain_raw.traces parent
+        JOIN blockchain_raw.traces child
         ON (parent.trace_address IS NULL OR starts_with(child.trace_address, concat(parent.trace_address, ',')))
         AND child.transaction_hash = parent.transaction_hash
         where parent.trace_type IN ('call', 'create')
         AND parent.error IS NOT NULL
     )
     SELECT traces.*, if((traces.error IS NOT NULL or nested_failed_traces.trace_address IS NOT NULL), 0, 1) AS status
-    FROM ethereum_blockchain_raw.traces AS traces
+    FROM blockchain_raw.traces AS traces
     LEFT JOIN nested_failed_traces ON nested_failed_traces.transaction_hash = traces.transaction_hash
     AND nested_failed_traces.trace_address = traces.trace_address
 )
@@ -34,7 +34,7 @@ SELECT
     TIMESTAMP_SECONDS(blocks.timestamp) AS block_timestamp,
     blocks.number AS block_number,
     blocks.hash AS block_hash
-FROM ethereum_blockchain_raw.blocks AS blocks
+FROM blockchain_raw.blocks AS blocks
     JOIN traces_with_status AS traces ON blocks.number = traces.block_number
 
 

--- a/dags/resources/stages/enrich/sqls/traces.sql
+++ b/dags/resources/stages/enrich/sqls/traces.sql
@@ -2,15 +2,15 @@ WITH traces_with_status AS (
     -- Find all nested traces of failed traces
     WITH nested_failed_traces AS (
         SELECT distinct child.transaction_hash, child.trace_address
-        FROM blockchain_raw.traces parent
-        JOIN blockchain_raw.traces child
+        FROM {{DATASET_NAME_RAW}}.traces parent
+        JOIN {{DATASET_NAME_RAW}}.traces child
         ON (parent.trace_address IS NULL OR starts_with(child.trace_address, concat(parent.trace_address, ',')))
         AND child.transaction_hash = parent.transaction_hash
         where parent.trace_type IN ('call', 'create')
         AND parent.error IS NOT NULL
     )
     SELECT traces.*, if((traces.error IS NOT NULL or nested_failed_traces.trace_address IS NOT NULL), 0, 1) AS status
-    FROM blockchain_raw.traces AS traces
+    FROM {{DATASET_NAME_RAW}}.traces AS traces
     LEFT JOIN nested_failed_traces ON nested_failed_traces.transaction_hash = traces.transaction_hash
     AND nested_failed_traces.trace_address = traces.trace_address
 )
@@ -34,7 +34,7 @@ SELECT
     TIMESTAMP_SECONDS(blocks.timestamp) AS block_timestamp,
     blocks.number AS block_number,
     blocks.hash AS block_hash
-FROM blockchain_raw.blocks AS blocks
+FROM {{DATASET_NAME_RAW}}.blocks AS blocks
     JOIN traces_with_status AS traces ON blocks.number = traces.block_number
 
 

--- a/dags/resources/stages/enrich/sqls/transactions.sql
+++ b/dags/resources/stages/enrich/sqls/transactions.sql
@@ -16,6 +16,6 @@ SELECT
     TIMESTAMP_SECONDS(blocks.timestamp) AS block_timestamp,
     blocks.number AS block_number,
     blocks.hash AS block_hash
-FROM blockchain_raw.blocks AS blocks
-    JOIN blockchain_raw.transactions AS transactions ON blocks.number = transactions.block_number
-    JOIN blockchain_raw.receipts AS receipts ON transactions.hash = receipts.transaction_hash
+FROM {{DATASET_NAME_RAW}}.blocks AS blocks
+    JOIN {{DATASET_NAME_RAW}}.transactions AS transactions ON blocks.number = transactions.block_number
+    JOIN {{DATASET_NAME_RAW}}.receipts AS receipts ON transactions.hash = receipts.transaction_hash

--- a/dags/resources/stages/enrich/sqls/transactions.sql
+++ b/dags/resources/stages/enrich/sqls/transactions.sql
@@ -16,6 +16,6 @@ SELECT
     TIMESTAMP_SECONDS(blocks.timestamp) AS block_timestamp,
     blocks.number AS block_number,
     blocks.hash AS block_hash
-FROM ethereum_blockchain_raw.blocks AS blocks
-    JOIN ethereum_blockchain_raw.transactions AS transactions ON blocks.number = transactions.block_number
-    JOIN ethereum_blockchain_raw.receipts AS receipts ON transactions.hash = receipts.transaction_hash
+FROM blockchain_raw.blocks AS blocks
+    JOIN blockchain_raw.transactions AS transactions ON blocks.number = transactions.block_number
+    JOIN blockchain_raw.receipts AS receipts ON transactions.hash = receipts.transaction_hash

--- a/dags/resources/stages/verify/sqls/blocks_count.sql
+++ b/dags/resources/stages/verify/sqls/blocks_count.sql
@@ -1,4 +1,4 @@
 SELECT IF(
-(SELECT MAX(number) FROM `bigquery-public-data.ethereum_blockchain.blocks`) + 1 =
-(SELECT COUNT(*) FROM `bigquery-public-data.ethereum_blockchain.blocks`), 1,
+(SELECT MAX(number) FROM `bigquery-public-data.blockchain.blocks`) + 1 =
+(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.blocks`), 1,
 CAST((SELECT 'Total number of blocks except genesis is not equal to last block number {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/blocks_count.sql
+++ b/dags/resources/stages/verify/sqls/blocks_count.sql
@@ -1,4 +1,4 @@
 SELECT IF(
-(SELECT MAX(number) FROM `bigquery-public-data.blockchain.blocks`) + 1 =
-(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.blocks`), 1,
+(SELECT MAX(number) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.blocks`) + 1 =
+(SELECT COUNT(*) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.blocks`), 1,
 CAST((SELECT 'Total number of blocks except genesis is not equal to last block number {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/blocks_have_latest.sql
+++ b/dags/resources/stages/verify/sqls/blocks_have_latest.sql
@@ -1,3 +1,3 @@
 SELECT IF(
-(SELECT COUNT(*) FROM `bigquery-public-data.ethereum_blockchain.blocks` WHERE DATE(timestamp) = '{{ds}}') > 0, 1,
+(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.blocks` WHERE DATE(timestamp) = '{{ds}}') > 0, 1,
 CAST((SELECT 'There are no blocks on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/blocks_have_latest.sql
+++ b/dags/resources/stages/verify/sqls/blocks_have_latest.sql
@@ -1,3 +1,3 @@
 SELECT IF(
-(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.blocks` WHERE DATE(timestamp) = '{{ds}}') > 0, 1,
+(SELECT COUNT(*) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.blocks` WHERE DATE(timestamp) = '{{ds}}') > 0, 1,
 CAST((SELECT 'There are no blocks on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/logs_have_latest.sql
+++ b/dags/resources/stages/verify/sqls/logs_have_latest.sql
@@ -1,3 +1,3 @@
 SELECT IF(
-(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.logs` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
+(SELECT COUNT(*) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.logs` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
 CAST((SELECT 'There are no logs on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/logs_have_latest.sql
+++ b/dags/resources/stages/verify/sqls/logs_have_latest.sql
@@ -1,3 +1,3 @@
 SELECT IF(
-(SELECT COUNT(*) FROM `bigquery-public-data.ethereum_blockchain.logs` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
+(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.logs` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
 CAST((SELECT 'There are no logs on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/token_transfers_have_latest.sql
+++ b/dags/resources/stages/verify/sqls/token_transfers_have_latest.sql
@@ -1,3 +1,3 @@
 SELECT IF(
-(SELECT COUNT(*) FROM `bigquery-public-data.ethereum_blockchain.token_transfers` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
+(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.token_transfers` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
 CAST((SELECT 'There are no token transfers on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/token_transfers_have_latest.sql
+++ b/dags/resources/stages/verify/sqls/token_transfers_have_latest.sql
@@ -1,3 +1,3 @@
 SELECT IF(
-(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.token_transfers` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
+(SELECT COUNT(*) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.token_transfers` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
 CAST((SELECT 'There are no token transfers on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/traces_blocks_count.sql
+++ b/dags/resources/stages/verify/sqls/traces_blocks_count.sql
@@ -1,5 +1,5 @@
 SELECT IF(
-(SELECT COUNT(DISTINCT(block_number)) FROM `bigquery-public-data.ethereum_blockchain.traces`
+(SELECT COUNT(DISTINCT(block_number)) FROM `bigquery-public-data.blockchain.traces`
 WHERE trace_type = 'reward' AND reward_type = 'block') =
-(SELECT COUNT(*) FROM `bigquery-public-data.ethereum_blockchain.blocks`) - 1, 1,
+(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.blocks`) - 1, 1,
 CAST((SELECT 'Total number of unique blocks in traces is not equal to block count minus 1 on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/traces_blocks_count.sql
+++ b/dags/resources/stages/verify/sqls/traces_blocks_count.sql
@@ -1,5 +1,5 @@
 SELECT IF(
-(SELECT COUNT(DISTINCT(block_number)) FROM `bigquery-public-data.blockchain.traces`
+(SELECT COUNT(DISTINCT(block_number)) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.traces`
 WHERE trace_type = 'reward' AND reward_type = 'block') =
-(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.blocks`) - 1, 1,
+(SELECT COUNT(*) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.blocks`) - 1, 1,
 CAST((SELECT 'Total number of unique blocks in traces is not equal to block count minus 1 on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/traces_contracts_count.sql
+++ b/dags/resources/stages/verify/sqls/traces_contracts_count.sql
@@ -1,8 +1,8 @@
 SELECT IF(
 (SELECT COUNT(1)
-FROM `bigquery-public-data.blockchain.traces` as traces
+FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.traces` as traces
 WHERE trace_type = 'create' AND trace_address IS NULL) =
 (SELECT COUNT(*)
-FROM `bigquery-public-data.blockchain.transactions` AS transactions
+FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.transactions` AS transactions
 WHERE receipt_contract_address IS NOT NULL), 1,
 CAST((SELECT 'Total number of traces with type create is not equal to number of contracts on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/traces_contracts_count.sql
+++ b/dags/resources/stages/verify/sqls/traces_contracts_count.sql
@@ -1,8 +1,8 @@
 SELECT IF(
 (SELECT COUNT(1)
-FROM `bigquery-public-data.ethereum_blockchain.traces` as traces
+FROM `bigquery-public-data.blockchain.traces` as traces
 WHERE trace_type = 'create' AND trace_address IS NULL) =
 (SELECT COUNT(*)
-FROM `bigquery-public-data.ethereum_blockchain.transactions` AS transactions
+FROM `bigquery-public-data.blockchain.transactions` AS transactions
 WHERE receipt_contract_address IS NOT NULL), 1,
 CAST((SELECT 'Total number of traces with type create is not equal to number of contracts on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/traces_transactions_count.sql
+++ b/dags/resources/stages/verify/sqls/traces_transactions_count.sql
@@ -1,5 +1,5 @@
 SELECT IF(
-(SELECT COUNT(transaction_hash) FROM `bigquery-public-data.ethereum_blockchain.traces`
+(SELECT COUNT(transaction_hash) FROM `bigquery-public-data.blockchain.traces`
 WHERE trace_address IS NULL AND transaction_hash IS NOT NULL) =
-(SELECT COUNT(*) FROM `bigquery-public-data.ethereum_blockchain.transactions`), 1,
+(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.transactions`), 1,
 CAST((SELECT 'Total number of traces with null address is not equal to transaction count on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/traces_transactions_count.sql
+++ b/dags/resources/stages/verify/sqls/traces_transactions_count.sql
@@ -1,5 +1,5 @@
 SELECT IF(
-(SELECT COUNT(transaction_hash) FROM `bigquery-public-data.blockchain.traces`
+(SELECT COUNT(transaction_hash) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.traces`
 WHERE trace_address IS NULL AND transaction_hash IS NOT NULL) =
-(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.transactions`), 1,
+(SELECT COUNT(*) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.transactions`), 1,
 CAST((SELECT 'Total number of traces with null address is not equal to transaction count on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/transactions_count.sql
+++ b/dags/resources/stages/verify/sqls/transactions_count.sql
@@ -1,3 +1,3 @@
-SELECT IF((SELECT sum(transaction_count) FROM `bigquery-public-data.blockchain.blocks`) =
-(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.transactions`), 1,
+SELECT IF((SELECT sum(transaction_count) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.blocks`) =
+(SELECT COUNT(*) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.transactions`), 1,
 CAST((SELECT 'Total number of transactions is not equal to sum of transaction_count in blocks table') AS INT64))

--- a/dags/resources/stages/verify/sqls/transactions_count.sql
+++ b/dags/resources/stages/verify/sqls/transactions_count.sql
@@ -1,3 +1,3 @@
-SELECT IF((SELECT sum(transaction_count) FROM `bigquery-public-data.ethereum_blockchain.blocks`) =
-(SELECT COUNT(*) FROM `bigquery-public-data.ethereum_blockchain.transactions`), 1,
+SELECT IF((SELECT sum(transaction_count) FROM `bigquery-public-data.blockchain.blocks`) =
+(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.transactions`), 1,
 CAST((SELECT 'Total number of transactions is not equal to sum of transaction_count in blocks table') AS INT64))

--- a/dags/resources/stages/verify/sqls/transactions_have_latest.sql
+++ b/dags/resources/stages/verify/sqls/transactions_have_latest.sql
@@ -1,3 +1,3 @@
 SELECT IF(
-(SELECT COUNT(*) FROM `bigquery-public-data.ethereum_blockchain.transactions` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
+(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.transactions` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
 CAST((SELECT 'There are no transactions on {{ds}}') AS INT64))

--- a/dags/resources/stages/verify/sqls/transactions_have_latest.sql
+++ b/dags/resources/stages/verify/sqls/transactions_have_latest.sql
@@ -1,3 +1,3 @@
 SELECT IF(
-(SELECT COUNT(*) FROM `bigquery-public-data.blockchain.transactions` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
+(SELECT COUNT(*) FROM `{{DESTINATION_DATASET_PROJECT_ID}}.{{DATASET_NAME}}.transactions` WHERE DATE(block_timestamp) = '{{ds}}') > 0, 1,
 CAST((SELECT 'There are no transactions on {{ds}}') AS INT64))


### PR DESCRIPTION
This PR will aim to solve 2 things:

1) It allows passing the parameters for traces as ENV VARs, specifically `--genesis-traces` & `--daofork-traces`. That is the default. It allows passing instead `--no-daofork-traces` in the ENV VAR as an option in `$EXPORT_DAOFORK_TRACES' & `$EXPORT_GENESIS_TRACES` for `--genesis-traces`.
2) It allows the passing of the ENV VAR `DATASET_NAME`, which is default as `ethereum_blockchain`. It then parses all SQL files and replaces the default `blockchain` datasetname with the one passed.

The script for the dataset name is super hacky, which I can refactor before merging. Just wanted to check which approach you're looking for before we can finalize this PR.