### PR TITLE
Add log parsing for Compound cToken contracts

### DIFF
--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_AccrueInterest.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_AccrueInterest",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_AccrueInterest.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "interestAccumulated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccrueInterest",
+            "type": "event",
+            "signature": "0x875352fb3fadeb8c0be7cbbe8ff761b308fa7033470cd0287f02f3436fd76cb9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_AccrueInterest",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "interestAccumulated",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Approval.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_Approval",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Approval.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event",
+            "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_Approval",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Borrow.json
@@ -1,0 +1,63 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Borrow",
+            "type": "event",
+            "signature": "0x13ed6866d4e1ee6da46f845c46d7e54120883d75c5ea9a2dacc1c4ca8984ab80"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_Borrow",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Borrow.json
@@ -33,7 +33,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_Borrow",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Failure.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_Failure",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Failure.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_Failure",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "error",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "info",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "detail",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_LiquidateBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidateBorrow",
+            "type": "event",
+            "signature": "0x298637f684da70674f26509b10f07ec2fbc77a335ab1e7d6215a4b2484d8bb52"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_LiquidateBorrow",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "liquidator",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "cTokenCollateral",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "seizeTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_LiquidateBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_LiquidateBorrow",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Mint.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_Mint",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Mint.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event",
+            "signature": "0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_Mint",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "minter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_NewAdmin",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event",
+            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_NewAdmin",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewComptroller.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_NewComptroller",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewComptroller.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldComptroller",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newComptroller",
+                    "type": "address"
+                }
+            ],
+            "name": "NewComptroller",
+            "type": "event",
+            "signature": "0x7ac369dbd14fa5ea3f473ed67cc9d598964a77501540ba6751eb0b3decf5870d"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_NewComptroller",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldComptroller",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newComptroller",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewMarketInterestRateModel.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldInterestRateModel",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newInterestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "NewMarketInterestRateModel",
+            "type": "event",
+            "signature": "0xedffc32e068c7c95dfd4bdfd5c4d939a084d6b11c4199eac8436ed234d72f926"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_NewMarketInterestRateModel",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewMarketInterestRateModel.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_NewMarketInterestRateModel",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewPendingAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event",
+            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_NewPendingAdmin",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewPendingAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_NewPendingAdmin",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewReserveFactor.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_NewReserveFactor",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_NewReserveFactor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldReserveFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newReserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewReserveFactor",
+            "type": "event",
+            "signature": "0xaaa68312e2ea9d50e16af5068410ab56e1a1fd06037b1a35664812c30f821460"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_NewReserveFactor",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Redeem.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Redeem",
+            "type": "event",
+            "signature": "0xe5b754fb1abb7f01b499791d0b820ae3b6af3424ac1c59768edb53f4ec31a929"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_Redeem",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "redeemer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Redeem.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_Redeem",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_RepayBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_RepayBorrow",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_RepayBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RepayBorrow",
+            "type": "event",
+            "signature": "0x1a2a22cb034d26d1854bdc6666a5b91fe25efbbb5dcad3b0355478d6f5c362a1"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_RepayBorrow",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "payer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_ReservesReduced.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_ReservesReduced",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_ReservesReduced.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "admin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "reduceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newTotalReserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReservesReduced",
+            "type": "event",
+            "signature": "0x3bad0c59cf2f06e7314077049f48a93578cd16f5ef92329f1dab1420a99c177e"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_ReservesReduced",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "admin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reduceAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newTotalReserves",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Transfer.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cBAT_event_Transfer",
         "table_description": "cToken for BAT on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cBAT_event_Transfer.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event",
+            "signature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cBAT_event_Transfer",
+        "table_description": "cToken for BAT on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "from",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_AccrueInterest.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_AccrueInterest",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_AccrueInterest.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "interestAccumulated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccrueInterest",
+            "type": "event",
+            "signature": "0x875352fb3fadeb8c0be7cbbe8ff761b308fa7033470cd0287f02f3436fd76cb9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_AccrueInterest",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "interestAccumulated",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Approval.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_Approval",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Approval.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event",
+            "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_Approval",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Borrow.json
@@ -1,0 +1,63 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Borrow",
+            "type": "event",
+            "signature": "0x13ed6866d4e1ee6da46f845c46d7e54120883d75c5ea9a2dacc1c4ca8984ab80"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_Borrow",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Borrow.json
@@ -33,7 +33,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_Borrow",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Failure.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_Failure",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "error",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "info",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "detail",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Failure.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_Failure",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_LiquidateBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidateBorrow",
+            "type": "event",
+            "signature": "0x298637f684da70674f26509b10f07ec2fbc77a335ab1e7d6215a4b2484d8bb52"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_LiquidateBorrow",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "liquidator",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "cTokenCollateral",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "seizeTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_LiquidateBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_LiquidateBorrow",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Mint.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_Mint",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Mint.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event",
+            "signature": "0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_Mint",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "minter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event",
+            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_NewAdmin",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_NewAdmin",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewComptroller.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldComptroller",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newComptroller",
+                    "type": "address"
+                }
+            ],
+            "name": "NewComptroller",
+            "type": "event",
+            "signature": "0x7ac369dbd14fa5ea3f473ed67cc9d598964a77501540ba6751eb0b3decf5870d"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_NewComptroller",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldComptroller",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newComptroller",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewComptroller.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_NewComptroller",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewMarketInterestRateModel.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_NewMarketInterestRateModel",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewMarketInterestRateModel.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldInterestRateModel",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newInterestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "NewMarketInterestRateModel",
+            "type": "event",
+            "signature": "0xedffc32e068c7c95dfd4bdfd5c4d939a084d6b11c4199eac8436ed234d72f926"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_NewMarketInterestRateModel",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewPendingAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event",
+            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_NewPendingAdmin",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewPendingAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_NewPendingAdmin",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewReserveFactor.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_NewReserveFactor",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_NewReserveFactor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldReserveFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newReserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewReserveFactor",
+            "type": "event",
+            "signature": "0xaaa68312e2ea9d50e16af5068410ab56e1a1fd06037b1a35664812c30f821460"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_NewReserveFactor",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Redeem.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_Redeem",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Redeem.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Redeem",
+            "type": "event",
+            "signature": "0xe5b754fb1abb7f01b499791d0b820ae3b6af3424ac1c59768edb53f4ec31a929"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_Redeem",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "redeemer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_RepayBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RepayBorrow",
+            "type": "event",
+            "signature": "0x1a2a22cb034d26d1854bdc6666a5b91fe25efbbb5dcad3b0355478d6f5c362a1"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_RepayBorrow",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "payer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_RepayBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_RepayBorrow",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_ReservesReduced.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_ReservesReduced",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_ReservesReduced.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "admin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "reduceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newTotalReserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReservesReduced",
+            "type": "event",
+            "signature": "0x3bad0c59cf2f06e7314077049f48a93578cd16f5ef92329f1dab1420a99c177e"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_ReservesReduced",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "admin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reduceAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newTotalReserves",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Transfer.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cDAI_event_Transfer",
         "table_description": "cToken for DAI on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cDAI_event_Transfer.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event",
+            "signature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cDAI_event_Transfer",
+        "table_description": "cToken for DAI on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "from",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_AccrueInterest.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "interestAccumulated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccrueInterest",
+            "type": "event",
+            "signature": "0x875352fb3fadeb8c0be7cbbe8ff761b308fa7033470cd0287f02f3436fd76cb9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_AccrueInterest",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "interestAccumulated",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_AccrueInterest.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_AccrueInterest",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Approval.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event",
+            "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_Approval",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Approval.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_Approval",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Borrow.json
@@ -1,0 +1,63 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Borrow",
+            "type": "event",
+            "signature": "0x13ed6866d4e1ee6da46f845c46d7e54120883d75c5ea9a2dacc1c4ca8984ab80"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_Borrow",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Borrow.json
@@ -33,7 +33,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_Borrow",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Failure.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_Failure",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "error",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "info",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "detail",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Failure.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_Failure",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_LiquidateBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidateBorrow",
+            "type": "event",
+            "signature": "0x298637f684da70674f26509b10f07ec2fbc77a335ab1e7d6215a4b2484d8bb52"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_LiquidateBorrow",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "liquidator",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "cTokenCollateral",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "seizeTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_LiquidateBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_LiquidateBorrow",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Mint.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event",
+            "signature": "0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_Mint",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "minter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Mint.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_Mint",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event",
+            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_NewAdmin",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_NewAdmin",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewComptroller.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_NewComptroller",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewComptroller.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldComptroller",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newComptroller",
+                    "type": "address"
+                }
+            ],
+            "name": "NewComptroller",
+            "type": "event",
+            "signature": "0x7ac369dbd14fa5ea3f473ed67cc9d598964a77501540ba6751eb0b3decf5870d"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_NewComptroller",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldComptroller",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newComptroller",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewMarketInterestRateModel.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldInterestRateModel",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newInterestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "NewMarketInterestRateModel",
+            "type": "event",
+            "signature": "0xedffc32e068c7c95dfd4bdfd5c4d939a084d6b11c4199eac8436ed234d72f926"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_NewMarketInterestRateModel",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewMarketInterestRateModel.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_NewMarketInterestRateModel",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewPendingAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event",
+            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_NewPendingAdmin",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewPendingAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_NewPendingAdmin",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewReserveFactor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldReserveFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newReserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewReserveFactor",
+            "type": "event",
+            "signature": "0xaaa68312e2ea9d50e16af5068410ab56e1a1fd06037b1a35664812c30f821460"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_NewReserveFactor",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_NewReserveFactor.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_NewReserveFactor",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Redeem.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_Redeem",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Redeem.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Redeem",
+            "type": "event",
+            "signature": "0xe5b754fb1abb7f01b499791d0b820ae3b6af3424ac1c59768edb53f4ec31a929"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_Redeem",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "redeemer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_RepayBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RepayBorrow",
+            "type": "event",
+            "signature": "0x1a2a22cb034d26d1854bdc6666a5b91fe25efbbb5dcad3b0355478d6f5c362a1"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_RepayBorrow",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "payer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_RepayBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_RepayBorrow",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_ReservesReduced.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "admin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "reduceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newTotalReserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReservesReduced",
+            "type": "event",
+            "signature": "0x3bad0c59cf2f06e7314077049f48a93578cd16f5ef92329f1dab1420a99c177e"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_ReservesReduced",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "admin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reduceAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newTotalReserves",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_ReservesReduced.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_ReservesReduced",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Transfer.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event",
+            "signature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cETH_event_Transfer",
+        "table_description": "cToken for ETH on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "from",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cETH_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cETH_event_Transfer.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cETH_event_Transfer",
         "table_description": "cToken for ETH on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_AccrueInterest.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_AccrueInterest",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_AccrueInterest.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "interestAccumulated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccrueInterest",
+            "type": "event",
+            "signature": "0x875352fb3fadeb8c0be7cbbe8ff761b308fa7033470cd0287f02f3436fd76cb9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_AccrueInterest",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "interestAccumulated",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Approval.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event",
+            "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_Approval",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Approval.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_Approval",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Borrow.json
@@ -1,0 +1,63 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Borrow",
+            "type": "event",
+            "signature": "0x13ed6866d4e1ee6da46f845c46d7e54120883d75c5ea9a2dacc1c4ca8984ab80"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_Borrow",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Borrow.json
@@ -33,7 +33,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_Borrow",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Failure.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_Failure",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Failure.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_Failure",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "error",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "info",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "detail",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_LiquidateBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidateBorrow",
+            "type": "event",
+            "signature": "0x298637f684da70674f26509b10f07ec2fbc77a335ab1e7d6215a4b2484d8bb52"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_LiquidateBorrow",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "liquidator",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "cTokenCollateral",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "seizeTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_LiquidateBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_LiquidateBorrow",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Mint.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event",
+            "signature": "0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_Mint",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "minter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Mint.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_Mint",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_NewAdmin",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event",
+            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_NewAdmin",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewComptroller.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldComptroller",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newComptroller",
+                    "type": "address"
+                }
+            ],
+            "name": "NewComptroller",
+            "type": "event",
+            "signature": "0x7ac369dbd14fa5ea3f473ed67cc9d598964a77501540ba6751eb0b3decf5870d"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_NewComptroller",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldComptroller",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newComptroller",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewComptroller.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_NewComptroller",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewMarketInterestRateModel.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_NewMarketInterestRateModel",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewMarketInterestRateModel.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldInterestRateModel",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newInterestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "NewMarketInterestRateModel",
+            "type": "event",
+            "signature": "0xedffc32e068c7c95dfd4bdfd5c4d939a084d6b11c4199eac8436ed234d72f926"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_NewMarketInterestRateModel",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewPendingAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_NewPendingAdmin",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewPendingAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event",
+            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_NewPendingAdmin",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewReserveFactor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldReserveFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newReserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewReserveFactor",
+            "type": "event",
+            "signature": "0xaaa68312e2ea9d50e16af5068410ab56e1a1fd06037b1a35664812c30f821460"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_NewReserveFactor",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_NewReserveFactor.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_NewReserveFactor",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Redeem.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_Redeem",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Redeem.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Redeem",
+            "type": "event",
+            "signature": "0xe5b754fb1abb7f01b499791d0b820ae3b6af3424ac1c59768edb53f4ec31a929"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_Redeem",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "redeemer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_RepayBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RepayBorrow",
+            "type": "event",
+            "signature": "0x1a2a22cb034d26d1854bdc6666a5b91fe25efbbb5dcad3b0355478d6f5c362a1"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_RepayBorrow",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "payer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_RepayBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_RepayBorrow",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_ReservesReduced.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "admin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "reduceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newTotalReserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReservesReduced",
+            "type": "event",
+            "signature": "0x3bad0c59cf2f06e7314077049f48a93578cd16f5ef92329f1dab1420a99c177e"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_ReservesReduced",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "admin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reduceAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newTotalReserves",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_ReservesReduced.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_ReservesReduced",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Transfer.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event",
+            "signature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cREP_event_Transfer",
+        "table_description": "cToken for REP on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "from",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cREP_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cREP_event_Transfer.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cREP_event_Transfer",
         "table_description": "cToken for REP on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_AccrueInterest.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_AccrueInterest",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_AccrueInterest.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "interestAccumulated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccrueInterest",
+            "type": "event",
+            "signature": "0x875352fb3fadeb8c0be7cbbe8ff761b308fa7033470cd0287f02f3436fd76cb9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_AccrueInterest",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "interestAccumulated",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Approval.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event",
+            "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_Approval",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Approval.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_Approval",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Borrow.json
@@ -33,7 +33,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_Borrow",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Borrow.json
@@ -1,0 +1,63 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Borrow",
+            "type": "event",
+            "signature": "0x13ed6866d4e1ee6da46f845c46d7e54120883d75c5ea9a2dacc1c4ca8984ab80"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_Borrow",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Failure.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_Failure",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Failure.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_Failure",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "error",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "info",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "detail",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_LiquidateBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidateBorrow",
+            "type": "event",
+            "signature": "0x298637f684da70674f26509b10f07ec2fbc77a335ab1e7d6215a4b2484d8bb52"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_LiquidateBorrow",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "liquidator",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "cTokenCollateral",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "seizeTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_LiquidateBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_LiquidateBorrow",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Mint.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event",
+            "signature": "0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_Mint",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "minter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Mint.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_Mint",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event",
+            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_NewAdmin",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_NewAdmin",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewComptroller.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_NewComptroller",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewComptroller.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldComptroller",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newComptroller",
+                    "type": "address"
+                }
+            ],
+            "name": "NewComptroller",
+            "type": "event",
+            "signature": "0x7ac369dbd14fa5ea3f473ed67cc9d598964a77501540ba6751eb0b3decf5870d"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_NewComptroller",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldComptroller",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newComptroller",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewMarketInterestRateModel.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_NewMarketInterestRateModel",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewMarketInterestRateModel.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldInterestRateModel",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newInterestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "NewMarketInterestRateModel",
+            "type": "event",
+            "signature": "0xedffc32e068c7c95dfd4bdfd5c4d939a084d6b11c4199eac8436ed234d72f926"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_NewMarketInterestRateModel",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewPendingAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_NewPendingAdmin",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewPendingAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event",
+            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_NewPendingAdmin",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewReserveFactor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldReserveFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newReserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewReserveFactor",
+            "type": "event",
+            "signature": "0xaaa68312e2ea9d50e16af5068410ab56e1a1fd06037b1a35664812c30f821460"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_NewReserveFactor",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_NewReserveFactor.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_NewReserveFactor",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Redeem.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Redeem",
+            "type": "event",
+            "signature": "0xe5b754fb1abb7f01b499791d0b820ae3b6af3424ac1c59768edb53f4ec31a929"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_Redeem",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "redeemer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Redeem.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_Redeem",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_RepayBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_RepayBorrow",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_RepayBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RepayBorrow",
+            "type": "event",
+            "signature": "0x1a2a22cb034d26d1854bdc6666a5b91fe25efbbb5dcad3b0355478d6f5c362a1"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_RepayBorrow",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "payer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_ReservesReduced.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "admin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "reduceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newTotalReserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReservesReduced",
+            "type": "event",
+            "signature": "0x3bad0c59cf2f06e7314077049f48a93578cd16f5ef92329f1dab1420a99c177e"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_ReservesReduced",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "admin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reduceAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newTotalReserves",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_ReservesReduced.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_ReservesReduced",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Transfer.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event",
+            "signature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cUSDC_event_Transfer",
+        "table_description": "cToken for USDC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "from",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cUSDC_event_Transfer.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cUSDC_event_Transfer",
         "table_description": "cToken for USDC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_AccrueInterest.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "interestAccumulated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccrueInterest",
+            "type": "event",
+            "signature": "0x875352fb3fadeb8c0be7cbbe8ff761b308fa7033470cd0287f02f3436fd76cb9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_AccrueInterest",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "interestAccumulated",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_AccrueInterest.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_AccrueInterest",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Approval.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event",
+            "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_Approval",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Approval.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_Approval",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Borrow.json
@@ -1,0 +1,63 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Borrow",
+            "type": "event",
+            "signature": "0x13ed6866d4e1ee6da46f845c46d7e54120883d75c5ea9a2dacc1c4ca8984ab80"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_Borrow",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Borrow.json
@@ -33,7 +33,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_Borrow",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Failure.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_Failure",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "error",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "info",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "detail",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Failure.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_Failure",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_LiquidateBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidateBorrow",
+            "type": "event",
+            "signature": "0x298637f684da70674f26509b10f07ec2fbc77a335ab1e7d6215a4b2484d8bb52"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_LiquidateBorrow",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "liquidator",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "cTokenCollateral",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "seizeTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_LiquidateBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_LiquidateBorrow",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Mint.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_Mint",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Mint.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event",
+            "signature": "0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_Mint",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "minter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event",
+            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_NewAdmin",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_NewAdmin",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewComptroller.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldComptroller",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newComptroller",
+                    "type": "address"
+                }
+            ],
+            "name": "NewComptroller",
+            "type": "event",
+            "signature": "0x7ac369dbd14fa5ea3f473ed67cc9d598964a77501540ba6751eb0b3decf5870d"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_NewComptroller",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldComptroller",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newComptroller",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewComptroller.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_NewComptroller",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewMarketInterestRateModel.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_NewMarketInterestRateModel",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewMarketInterestRateModel.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldInterestRateModel",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newInterestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "NewMarketInterestRateModel",
+            "type": "event",
+            "signature": "0xedffc32e068c7c95dfd4bdfd5c4d939a084d6b11c4199eac8436ed234d72f926"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_NewMarketInterestRateModel",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewPendingAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_NewPendingAdmin",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewPendingAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event",
+            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_NewPendingAdmin",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewReserveFactor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldReserveFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newReserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewReserveFactor",
+            "type": "event",
+            "signature": "0xaaa68312e2ea9d50e16af5068410ab56e1a1fd06037b1a35664812c30f821460"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_NewReserveFactor",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_NewReserveFactor.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_NewReserveFactor",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Redeem.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_Redeem",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Redeem.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Redeem",
+            "type": "event",
+            "signature": "0xe5b754fb1abb7f01b499791d0b820ae3b6af3424ac1c59768edb53f4ec31a929"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_Redeem",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "redeemer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_RepayBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_RepayBorrow",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_RepayBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RepayBorrow",
+            "type": "event",
+            "signature": "0x1a2a22cb034d26d1854bdc6666a5b91fe25efbbb5dcad3b0355478d6f5c362a1"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_RepayBorrow",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "payer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_ReservesReduced.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "admin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "reduceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newTotalReserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReservesReduced",
+            "type": "event",
+            "signature": "0x3bad0c59cf2f06e7314077049f48a93578cd16f5ef92329f1dab1420a99c177e"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_ReservesReduced",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "admin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reduceAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newTotalReserves",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_ReservesReduced.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_ReservesReduced",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Transfer.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event",
+            "signature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cWBTC_event_Transfer",
+        "table_description": "cToken for WBTC on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "from",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWBTC_event_Transfer.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cWBTC_event_Transfer",
         "table_description": "cToken for WBTC on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_AccrueInterest.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "interestAccumulated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AccrueInterest",
+            "type": "event",
+            "signature": "0x875352fb3fadeb8c0be7cbbe8ff761b308fa7033470cd0287f02f3436fd76cb9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_AccrueInterest",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "interestAccumulated",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_AccrueInterest.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_AccrueInterest.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_AccrueInterest",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Approval.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_Approval",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Approval.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event",
+            "signature": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_Approval",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Borrow.json
@@ -33,7 +33,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_Borrow",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Borrow.json
@@ -1,0 +1,63 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrowAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Borrow",
+            "type": "event",
+            "signature": "0x13ed6866d4e1ee6da46f845c46d7e54120883d75c5ea9a2dacc1c4ca8984ab80"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_Borrow",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrowAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Failure.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_Failure",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Failure.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "error",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "info",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "detail",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Failure",
+            "type": "event",
+            "signature": "0x45b96fe442630264581b197e84bbada861235052c5a1aadfff9ea4e40a969aa0"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_Failure",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "error",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "info",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "detail",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_LiquidateBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "cTokenCollateral",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "seizeTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidateBorrow",
+            "type": "event",
+            "signature": "0x298637f684da70674f26509b10f07ec2fbc77a335ab1e7d6215a4b2484d8bb52"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_LiquidateBorrow",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "liquidator",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "cTokenCollateral",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "seizeTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_LiquidateBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_LiquidateBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_LiquidateBorrow",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Mint.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "mintTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event",
+            "signature": "0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_Mint",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "minter",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "mintTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Mint.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_Mint",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewAdmin",
+            "type": "event",
+            "signature": "0xf9ffabca9c8276e99321725bcb43fb076a6c66a54b7f21c4e8146d8519b417dc"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_NewAdmin",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_NewAdmin",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewComptroller.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldComptroller",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newComptroller",
+                    "type": "address"
+                }
+            ],
+            "name": "NewComptroller",
+            "type": "event",
+            "signature": "0x7ac369dbd14fa5ea3f473ed67cc9d598964a77501540ba6751eb0b3decf5870d"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_NewComptroller",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldComptroller",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newComptroller",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewComptroller.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewComptroller.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_NewComptroller",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewMarketInterestRateModel.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldInterestRateModel",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newInterestRateModel",
+                    "type": "address"
+                }
+            ],
+            "name": "NewMarketInterestRateModel",
+            "type": "event",
+            "signature": "0xedffc32e068c7c95dfd4bdfd5c4d939a084d6b11c4199eac8436ed234d72f926"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_NewMarketInterestRateModel",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newInterestRateModel",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewMarketInterestRateModel.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewMarketInterestRateModel.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_NewMarketInterestRateModel",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewPendingAdmin.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldPendingAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newPendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPendingAdmin",
+            "type": "event",
+            "signature": "0xca4f2f25d0898edd99413412fb94012f9e54ec8142f9b093e7720646a95b16a9"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_NewPendingAdmin",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newPendingAdmin",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewPendingAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewPendingAdmin.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_NewPendingAdmin",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewReserveFactor.json
@@ -23,7 +23,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_NewReserveFactor",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewReserveFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_NewReserveFactor.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldReserveFactorMantissa",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newReserveFactorMantissa",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewReserveFactor",
+            "type": "event",
+            "signature": "0xaaa68312e2ea9d50e16af5068410ab56e1a1fd06037b1a35664812c30f821460"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_NewReserveFactor",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "oldReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newReserveFactorMantissa",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Redeem.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_Redeem",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Redeem.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "redeemTokens",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Redeem",
+            "type": "event",
+            "signature": "0xe5b754fb1abb7f01b499791d0b820ae3b6af3424ac1c59768edb53f4ec31a929"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_Redeem",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "redeemer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "redeemTokens",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_RepayBorrow.json
@@ -1,0 +1,73 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "payer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "repayAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "accountBorrows",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "totalBorrows",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RepayBorrow",
+            "type": "event",
+            "signature": "0x1a2a22cb034d26d1854bdc6666a5b91fe25efbbb5dcad3b0355478d6f5c362a1"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_RepayBorrow",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "payer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "borrower",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "repayAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "accountBorrows",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "totalBorrows",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_RepayBorrow.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_RepayBorrow.json
@@ -38,7 +38,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_RepayBorrow",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_ReservesReduced.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "admin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "reduceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newTotalReserves",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReservesReduced",
+            "type": "event",
+            "signature": "0x3bad0c59cf2f06e7314077049f48a93578cd16f5ef92329f1dab1420a99c177e"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_ReservesReduced",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "admin",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "reduceAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newTotalReserves",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_ReservesReduced.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_ReservesReduced.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_ReservesReduced",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Transfer.json
@@ -28,7 +28,6 @@
         "field_mapping": {}
     },
     "table": {
-        "project_name": "blockchain-etl",
         "dataset_name": "compound",
         "table_name": "cZRX_event_Transfer",
         "table_description": "cToken for ZRX on the Compound Protocol.",

--- a/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cZRX_event_Transfer.json
@@ -1,0 +1,53 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event",
+            "signature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "project_name": "blockchain-etl",
+        "dataset_name": "compound",
+        "table_name": "cZRX_event_Transfer",
+        "table_description": "cToken for ZRX on the Compound Protocol.",
+        "schema": [
+            {
+                "name": "from",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "amount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Log parsing for all cTokens on the Compound Protocol:
- cBAT
- cDAI
- cETH
- cREP
- cUSDC
- cWBTC
- cZRX

Used contract addresses and ABIs listed for mainnet here: https://compound.finance/developers#networks