### PR TITLE
Add Maker events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/maker/AuthGemJoin_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/AuthGemJoin_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xad37fd42185ba63009177058208dd1be4b136e6b",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "AuthGemJoin_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Cat_event_Bite.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Cat_event_Bite.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x78f2c2af65126834c51822f56be0d7469d7a523e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "ilk",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "urn",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "ink",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "art",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "tab",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "flip",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Bite",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Cat_event_Bite",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "ilk",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "urn",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "ink",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "art",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "tab",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "flip",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Cat_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Cat_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x78f2c2af65126834c51822f56be0d7469d7a523e",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Cat_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSChief_event_Etch.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSChief_event_Etch.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9ef05f7f6deb616fd37ac3c959a2ddd25a54e4f5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "slate",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "Etch",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSChief_event_Etch",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "slate",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSChief_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSChief_event_LogNote.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9ef05f7f6deb616fd37ac3c959a2ddd25a54e4f5",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSChief_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "foo",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bar",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fax",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSChief_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSChief_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9ef05f7f6deb616fd37ac3c959a2ddd25a54e4f5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSChief_event_LogSetAuthority",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "authority",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSChief_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSChief_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9ef05f7f6deb616fd37ac3c959a2ddd25a54e4f5",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSChief_event_LogSetOwner",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSChief_old_event_Etch.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSChief_old_event_Etch.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x8e2a84d6ade1e7fffee039a35ef5f19f13057152",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "slate",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "Etch",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSChief_old_event_Etch",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "slate",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSChief_old_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSChief_old_event_LogNote.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x8e2a84d6ade1e7fffee039a35ef5f19f13057152",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSChief_old_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "foo",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bar",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fax",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSChief_old_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSChief_old_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x8e2a84d6ade1e7fffee039a35ef5f19f13057152",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSChief_old_event_LogSetAuthority",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "authority",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSChief_old_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSChief_old_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x8e2a84d6ade1e7fffee039a35ef5f19f13057152",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSChief_old_event_LogSetOwner",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSGuard_event_LogForbid.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSGuard_event_LogForbid.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x315cbb88168396d12e1a255f9cb935408fe80710",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "src",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "dst",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "LogForbid",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSGuard_event_LogForbid",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "src",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "dst",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSGuard_event_LogPermit.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSGuard_event_LogPermit.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x315cbb88168396d12e1a255f9cb935408fe80710",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "src",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "dst",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "LogPermit",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSGuard_event_LogPermit",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "src",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "dst",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSGuard_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSGuard_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x315cbb88168396d12e1a255f9cb935408fe80710",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSGuard_event_LogSetAuthority",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "authority",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSGuard_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSGuard_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x315cbb88168396d12e1a255f9cb935408fe80710",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSGuard_event_LogSetOwner",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSPause_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSPause_event_LogNote.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xbe286431454714f511008713973d3b053a2d38f3",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSPause_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "foo",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bar",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fax",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSPause_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSPause_event_LogSetAuthority.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xbe286431454714f511008713973d3b053a2d38f3",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSPause_event_LogSetAuthority",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "authority",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSPause_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSPause_event_LogSetOwner.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xbe286431454714f511008713973d3b053a2d38f3",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSPause_event_LogSetOwner",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSProxyFactory_event_Created.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSProxyFactory_event_Created.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xa26e15c895efc0616177b7c1e7270a4c7d51c997",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "cache",
+                    "type": "address"
+                }
+            ],
+            "name": "Created",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSProxyFactory_event_Created",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "proxy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "cache",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSProxy_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSProxy_event_LogNote.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x1b93556ab8dccef01cd7823c617a6d340f53fb58",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSProxy_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "foo",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bar",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fax",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSProxy_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSProxy_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x1b93556ab8dccef01cd7823c617a6d340f53fb58",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSProxy_event_LogSetAuthority",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "authority",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSProxy_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSProxy_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x1b93556ab8dccef01cd7823c617a6d340f53fb58",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSProxy_event_LogSetOwner",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_Approval.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_MKR_event_Approval",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spender",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "value",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_Burn.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_Burn.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_MKR_event_Burn",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_LogNote.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_MKR_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "foo",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bar",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fax",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_MKR_event_LogSetAuthority",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "authority",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_MKR_event_LogSetOwner",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_Mint.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_MKR_event_Mint",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_MKR_event_Transfer.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_MKR_event_Transfer",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "from",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "value",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_Approval.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_SAI_event_Approval",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "src",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_Burn.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_Burn.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_SAI_event_Burn",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_LogNote.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_SAI_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "foo",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bar",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fax",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_SAI_event_LogSetAuthority",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "authority",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_SAI_event_LogSetOwner",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_Mint.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_SAI_event_Mint",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSToken_SAI_event_Transfer.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSToken_SAI_event_Transfer",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "src",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "dst",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSValue_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSValue_event_LogNote.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x54003dbf6ae6cba6ddae571ccdc34d834b44ab1e",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSValue_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "foo",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bar",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fax",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSValue_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSValue_event_LogSetAuthority.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x54003dbf6ae6cba6ddae571ccdc34d834b44ab1e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSValue_event_LogSetAuthority",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "authority",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DSValue_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DSValue_event_LogSetOwner.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x54003dbf6ae6cba6ddae571ccdc34d834b44ab1e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DSValue_event_LogSetOwner",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DaiJoin_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DaiJoin_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x9759a6ac90977b93b58547b4a71c78317f391a28",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DaiJoin_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Dai_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Dai_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Dai_event_Approval",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "src",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Dai_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Dai_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Dai_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Dai_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Dai_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Dai_event_Transfer",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "src",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "dst",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DssCdpManager_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DssCdpManager_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x5ef30b9986345249bc32d8928b7ee64de9435e39",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DssCdpManager_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DssCdpManager_event_NewCdp.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DssCdpManager_event_NewCdp.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x5ef30b9986345249bc32d8928b7ee64de9435e39",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "own",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "cdp",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewCdp",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DssCdpManager_event_NewCdp",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "own",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "cdp",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DssDeploy_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DssDeploy_event_LogSetAuthority.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xbaa65281c2fa2baacb2cb550ba051525a480d3f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DssDeploy_event_LogSetAuthority",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "authority",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/DssDeploy_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/maker/DssDeploy_event_LogSetOwner.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xbaa65281c2fa2baacb2cb550ba051525a480d3f4",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "DssDeploy_event_LogSetOwner",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/End_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/End_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xab14d3ce3f733cacb76ec2abe7d2fcb00c99f3d5",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "End_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Flapper_event_Kick.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Flapper_event_Kick.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xdfe0fb1be2a52cdbf8fb962d5701d7fd0902db9f",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "lot",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "bid",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Kick",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Flapper_event_Kick",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "lot",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bid",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Flapper_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Flapper_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xdfe0fb1be2a52cdbf8fb962d5701d7fd0902db9f",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Flapper_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Flipper_BAT_event_Kick.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Flipper_BAT_event_Kick.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xaa745404d55f88c108a28c86abe7b5a1e7817c07",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "lot",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "bid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "tab",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "gal",
+                    "type": "address"
+                }
+            ],
+            "name": "Kick",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Flipper_BAT_event_Kick",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "lot",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bid",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "tab",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "gal",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Flipper_BAT_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Flipper_BAT_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xaa745404d55f88c108a28c86abe7b5a1e7817c07",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Flipper_BAT_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Flipper_ETH_event_Kick.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Flipper_ETH_event_Kick.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xd8a04f5412223f513dc55f839574430f5ec15531",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "lot",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "bid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "tab",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "gal",
+                    "type": "address"
+                }
+            ],
+            "name": "Kick",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Flipper_ETH_event_Kick",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "lot",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bid",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "tab",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "gal",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Flipper_ETH_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Flipper_ETH_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xd8a04f5412223f513dc55f839574430f5ec15531",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Flipper_ETH_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Flipper_SAI_event_Kick.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Flipper_SAI_event_Kick.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x5432b2f3c0dff95aa191c45e5cbd539e2820ae72",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "lot",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "bid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "tab",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "gal",
+                    "type": "address"
+                }
+            ],
+            "name": "Kick",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Flipper_SAI_event_Kick",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "lot",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bid",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "tab",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "gal",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Flipper_SAI_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Flipper_SAI_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x5432b2f3c0dff95aa191c45e5cbd539e2820ae72",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Flipper_SAI_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Flopper_event_Kick.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Flopper_event_Kick.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xbe00fe8dfd9c079f1e5f5ad7ae9a3ad2c571fcac",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "lot",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "bid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "gal",
+                    "type": "address"
+                }
+            ],
+            "name": "Kick",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Flopper_event_Kick",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "lot",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bid",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "gal",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Flopper_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Flopper_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xbe00fe8dfd9c079f1e5f5ad7ae9a3ad2c571fcac",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Flopper_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/GemJoin_BAT_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/GemJoin_BAT_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x3d0b1912b66114d4096f48a8cee3a56c231772ca",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "GemJoin_BAT_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/GemJoin_ETH_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/GemJoin_ETH_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x2f0b23f53734252bda2277357e97e1517d6b042a",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "GemJoin_ETH_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Jug_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Jug_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x19c0976f590d67707e62397c87829d896dc0f1f1",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Jug_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/OSM_BAT_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/OSM_BAT_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb4eb54af9cc7882df0121d26c5b97e802915abe6",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "OSM_BAT_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/OSM_BAT_event_LogValue.json
+++ b/dags/resources/stages/parse/table_definitions/maker/OSM_BAT_event_LogValue.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xb4eb54af9cc7882df0121d26c5b97e802915abe6",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "val",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "LogValue",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "OSM_BAT_event_LogValue",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "val",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/OSM_ETH_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/OSM_ETH_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x81fe72b5a8d1a857d176c3e7d5bd2679a9b85763",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "OSM_ETH_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/OSM_ETH_event_LogValue.json
+++ b/dags/resources/stages/parse/table_definitions/maker/OSM_ETH_event_LogValue.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x81fe72b5a8d1a857d176c3e7d5bd2679a9b85763",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "val",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "LogValue",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "OSM_ETH_event_LogValue",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "val",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Pot_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Pot_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x197e90f9fad81970ba7976f33cbd77088e5d7cf7",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Pot_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Redeemer_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Redeemer_event_LogNote.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x642ae78fafbb8032da552d619ad43f1d81e4dd7c",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Redeemer_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "foo",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bar",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fax",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Redeemer_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Redeemer_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x642ae78fafbb8032da552d619ad43f1d81e4dd7c",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Redeemer_event_LogSetAuthority",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "authority",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Redeemer_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Redeemer_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x642ae78fafbb8032da552d619ad43f1d81e4dd7c",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Redeemer_event_LogSetOwner",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/SaiTub_event_LogNewCup.json
+++ b/dags/resources/stages/parse/table_definitions/maker/SaiTub_event_LogNewCup.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x448a5065aebb8e423f0896e6c5d525c040f59af3",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "lad",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "cup",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "LogNewCup",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "SaiTub_event_LogNewCup",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "lad",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "cup",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/SaiTub_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/SaiTub_event_LogNote.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x448a5065aebb8e423f0896e6c5d525c040f59af3",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "SaiTub_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "guy",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "foo",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "bar",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "wad",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fax",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/SaiTub_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/maker/SaiTub_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x448a5065aebb8e423f0896e6c5d525c040f59af3",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "SaiTub_event_LogSetAuthority",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "authority",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/SaiTub_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/maker/SaiTub_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x448a5065aebb8e423f0896e6c5d525c040f59af3",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "SaiTub_event_LogSetOwner",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Spotter_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Spotter_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x65c79fcb50ca1594b025960e539ed7a9a6d434a3",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Spotter_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Spotter_event_Poke.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Spotter_event_Poke.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x65c79fcb50ca1594b025960e539ed7a9a6d434a3",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "ilk",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "val",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "spot",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Poke",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Spotter_event_Poke",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "ilk",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "val",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "spot",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Vat_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Vat_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x35d1b3f3d7966a1dfe207aa4514c12a259a0492b",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg3",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Vat_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg3",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/Vow_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/maker/Vow_event_LogNote.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xa950524441892a31ebddf91d3ceefa04bf454466",
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes4",
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "arg2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "maker",
+        "table_name": "Vow_event_LogNote",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "sig",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "usr",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg1",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "arg2",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Included mostly contracts that are listed here: https://changelog.makerdao.com/releases/mainnet/1.0.0/contracts.json

But also some of the older contracts focused on SAI.

I used ABI Parser to generate these files (with some manual changes). In particular, I had to rename a few tables, as there were duplicated contract names. For example, there's both `DSToken_SAI` and `DSToken_MKR`.