### PR TITLE
Add new 0x exchange contract (v3.0)

### DIFF
--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_AssetProxyRegistered.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_AssetProxyRegistered.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes4",
+                    "name": "id",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "assetProxy",
+                    "type": "address"
+                }
+            ],
+            "name": "AssetProxyRegistered",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v3_0_event_AssetProxyRegistered",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "id",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "assetProxy",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_Cancel.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_Cancel.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "makerAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "feeRecipientAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "makerAssetData",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "takerAssetData",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "senderAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "Cancel",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v3_0_event_Cancel",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "makerAddress",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "feeRecipientAddress",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "makerAssetData",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerAssetData",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "senderAddress",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_CancelUpTo.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_CancelUpTo.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "makerAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "orderSenderAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "orderEpoch",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CancelUpTo",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v3_0_event_CancelUpTo",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "makerAddress",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "orderSenderAddress",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "orderEpoch",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_Fill.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_Fill.json
@@ -1,0 +1,175 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "makerAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "feeRecipientAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "makerAssetData",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "takerAssetData",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "makerFeeAssetData",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "takerFeeAssetData",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "takerAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "senderAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "makerAssetFilledAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "takerAssetFilledAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "makerFeePaid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "takerFeePaid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "protocolFeePaid",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Fill",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v3_0_event_Fill",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "makerAddress",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "feeRecipientAddress",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "makerAssetData",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerAssetData",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "makerFeeAssetData",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerFeeAssetData",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerAddress",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "senderAddress",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "makerAssetFilledAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerAssetFilledAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "makerFeePaid",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerFeePaid",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "protocolFeePaid",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v3_0_event_OwnershipTransferred",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "previousOwner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newOwner",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_ProtocolFeeCollectorAddress.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_ProtocolFeeCollectorAddress.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldProtocolFeeCollector",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "updatedProtocolFeeCollector",
+                    "type": "address"
+                }
+            ],
+            "name": "ProtocolFeeCollectorAddress",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v3_0_event_ProtocolFeeCollectorAddress",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "oldProtocolFeeCollector",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "updatedProtocolFeeCollector",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_ProtocolFeeMultiplier.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_ProtocolFeeMultiplier.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldProtocolFeeMultiplier",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "updatedProtocolFeeMultiplier",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProtocolFeeMultiplier",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v3_0_event_ProtocolFeeMultiplier",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "oldProtocolFeeMultiplier",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "updatedProtocolFeeMultiplier",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_SignatureValidatorApproval.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_SignatureValidatorApproval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "signerAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "validatorAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "isApproved",
+                    "type": "bool"
+                }
+            ],
+            "name": "SignatureValidatorApproval",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v3_0_event_SignatureValidatorApproval",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "signerAddress",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "validatorAddress",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "isApproved",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_TransactionExecution.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v3_0_event_TransactionExecution.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "transactionHash",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "TransactionExecution",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v3_0_event_TransactionExecution",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "transactionHash",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
0x just launched their new Exchange contract (v3.0): `0x61935cbdd02287b511119ddb11aeb42f1593b7ef`.

This PR adds event tables for this contract to the `zeroex` dataset.