### PR TITLE
Add 2nd ENS registrar controller

### DIFF
--- a/dags/resources/stages/parse/table_definitions/ens/ETHRegistrarController2_event_NameRegistered.json
+++ b/dags/resources/stages/parse/table_definitions/ens/ETHRegistrarController2_event_NameRegistered.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "label",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "cost",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "expires",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NameRegistered",
+            "type": "event"
+        },
+        "contract_address": "0xb22c1c159d12461ea124b0deb4b5b93020e6ad16",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ens",
+        "schema": [
+            {
+                "description": "",
+                "name": "name",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "label",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "cost",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "expires",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ETHRegistrarController2_event_NameRegistered"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/ens/ETHRegistrarController2_event_NameRenewed.json
+++ b/dags/resources/stages/parse/table_definitions/ens/ETHRegistrarController2_event_NameRenewed.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "label",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "cost",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "expires",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NameRenewed",
+            "type": "event"
+        },
+        "contract_address": "0xb22c1c159d12461ea124b0deb4b5b93020e6ad16",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ens",
+        "schema": [
+            {
+                "description": "",
+                "name": "name",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "label",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "cost",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "expires",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ETHRegistrarController2_event_NameRenewed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/ens/ETHRegistrarController2_event_NewPriceOracle.json
+++ b/dags/resources/stages/parse/table_definitions/ens/ETHRegistrarController2_event_NewPriceOracle.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oracle",
+                    "type": "address"
+                }
+            ],
+            "name": "NewPriceOracle",
+            "type": "event"
+        },
+        "contract_address": "0xb22c1c159d12461ea124b0deb4b5b93020e6ad16",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ens",
+        "schema": [
+            {
+                "description": "",
+                "name": "oracle",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ETHRegistrarController2_event_NewPriceOracle"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/ens/ETHRegistrarController2_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/ens/ETHRegistrarController2_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0xb22c1c159d12461ea124b0deb4b5b93020e6ad16",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ens",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ETHRegistrarController2_event_OwnershipTransferred"
+    }
+}


### PR DESCRIPTION
This contract is marked as "ENS: ETH Registrar Controller 2" on Etherscan: `0xb22c1c159d12461ea124b0deb4b5b93020e6ad16`

I'm adding it to have a complete view of the ENS addresses.