### PR TITLE
Added CheezeWizards events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_AscensionChallenged.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_AscensionChallenged.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "ascendingWizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "challengingWizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "commitment",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "AscensionChallenged",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "ascendingWizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "challengingWizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "commitment",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_AscensionChallenged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_AscensionComplete.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_AscensionComplete.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "power",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AscensionComplete",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_AscensionComplete"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_AscensionPairUp.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_AscensionPairUp.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId2",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AscensionPairUp",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId2",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_AscensionPairUp"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_AscensionStart.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_AscensionStart.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AscensionStart",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_AscensionStart"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_CEOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_CEOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCeo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCeo",
+                    "type": "address"
+                }
+            ],
+            "name": "CEOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCeo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCeo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_CEOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_CFOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_CFOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCfo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCfo",
+                    "type": "address"
+                }
+            ],
+            "name": "CFOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCfo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCfo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_CFOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_COOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_COOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCoo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCoo",
+                    "type": "address"
+                }
+            ],
+            "name": "COOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCoo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCoo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_COOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_DuelEnd.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_DuelEnd.json
@@ -1,0 +1,91 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "duelId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId2",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "moveSet1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "moveSet2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "power1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "power2",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DuelEnd",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "duelId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId2",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "moveSet1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "moveSet2",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power2",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_DuelEnd"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_DuelStart.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_DuelStart.json
@@ -1,0 +1,91 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "duelId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId2",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "timeoutBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "isAscensionBattle",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "name": "commit1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "commit2",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "DuelStart",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "duelId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId2",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "timeoutBlock",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "isAscensionBattle",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "commit1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "commit2",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_DuelStart"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_DuelTimeOut.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_DuelTimeOut.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "duelId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId2",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "power1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "power2",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DuelTimeOut",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "duelId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId2",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power2",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_DuelTimeOut"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_OneSidedCommitAdded.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_OneSidedCommitAdded.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "committingWizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "otherWizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "committingWizardNonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "otherWizardNonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "commitment",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "OneSidedCommitAdded",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "committingWizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "otherWizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "committingWizardNonce",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "otherWizardNonce",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "commitment",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_OneSidedCommitAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_OneSidedCommitCancelled.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_OneSidedCommitCancelled.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "OneSidedCommitCancelled",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_OneSidedCommitCancelled"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_OneSidedRevealAdded.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_OneSidedRevealAdded.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "duelId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "committingWizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "otherWizardId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "OneSidedRevealAdded",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "duelId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "committingWizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "otherWizardId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_OneSidedRevealAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_Paused.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "pauseEndedBlock",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "pauseEndedBlock",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_PowerTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_PowerTransferred.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "sendingWizId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "receivingWizId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "amountTransferred",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "reason",
+                    "type": "uint8"
+                }
+            ],
+            "name": "PowerTransferred",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "sendingWizId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "receivingWizId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountTransferred",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reason",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_PowerTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_PrizeClaimed.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_PrizeClaimed.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "claimingWinnerId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "prizeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PrizeClaimed",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "claimingWinnerId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "prizeAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_PrizeClaimed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_Revive.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_Revive.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "power",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Revive",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_Revive"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_WizardElimination.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_unp_event_WizardElimination.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WizardElimination",
+            "type": "event"
+        },
+        "contract_address": "0xdd903896aacc543abeef0deea9b2a27496f762ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_WizardElimination"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_AscensionChallenged.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_AscensionChallenged.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "ascendingWizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "challengingWizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "commitment",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "AscensionChallenged",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "ascendingWizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "challengingWizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "commitment",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_AscensionChallenged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_AscensionComplete.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_AscensionComplete.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "power",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AscensionComplete",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_AscensionComplete"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_AscensionPairUp.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_AscensionPairUp.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId2",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AscensionPairUp",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId2",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_AscensionPairUp"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_AscensionStart.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_AscensionStart.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AscensionStart",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_AscensionStart"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_CEOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_CEOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCeo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCeo",
+                    "type": "address"
+                }
+            ],
+            "name": "CEOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCeo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCeo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_CEOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_CFOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_CFOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCfo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCfo",
+                    "type": "address"
+                }
+            ],
+            "name": "CFOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCfo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCfo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_CFOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_COOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_COOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCoo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCoo",
+                    "type": "address"
+                }
+            ],
+            "name": "COOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCoo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCoo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_COOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_DuelEnd.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_DuelEnd.json
@@ -1,0 +1,91 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "duelId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId2",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "moveSet1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "moveSet2",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "power1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "power2",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DuelEnd",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "duelId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId2",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "moveSet1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "moveSet2",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power2",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_DuelEnd"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_DuelStart.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_DuelStart.json
@@ -1,0 +1,91 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "duelId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId2",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "timeoutBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "isAscensionBattle",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "name": "commit1",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "commit2",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "DuelStart",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "duelId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId2",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "timeoutBlock",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "isAscensionBattle",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "commit1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "commit2",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_DuelStart"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_DuelTimeOut.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_DuelTimeOut.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "duelId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "wizardId2",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "power1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "power2",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DuelTimeOut",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "duelId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wizardId2",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power2",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_DuelTimeOut"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_OneSidedCommitAdded.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_OneSidedCommitAdded.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "committingWizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "otherWizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "committingWizardNonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "otherWizardNonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "commitment",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "OneSidedCommitAdded",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "committingWizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "otherWizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "committingWizardNonce",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "otherWizardNonce",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "commitment",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_OneSidedCommitAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_OneSidedCommitCancelled.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_OneSidedCommitCancelled.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "OneSidedCommitCancelled",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_OneSidedCommitCancelled"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_OneSidedRevealAdded.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_OneSidedRevealAdded.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "duelId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "committingWizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "otherWizardId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "OneSidedRevealAdded",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "duelId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "committingWizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "otherWizardId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_OneSidedRevealAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_Paused.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "pauseEndedBlock",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "pauseEndedBlock",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_PowerTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_PowerTransferred.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "sendingWizId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "receivingWizId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "amountTransferred",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "reason",
+                    "type": "uint8"
+                }
+            ],
+            "name": "PowerTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "sendingWizId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "receivingWizId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountTransferred",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reason",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_PowerTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_PrizeClaimed.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_PrizeClaimed.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "claimingWinnerId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "prizeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PrizeClaimed",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "claimingWinnerId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "prizeAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_PrizeClaimed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_Revive.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_Revive.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "power",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Revive",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_Revive"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_WizardElimination.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/BasicTournament_v1_event_WizardElimination.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WizardElimination",
+            "type": "event"
+        },
+        "contract_address": "0x6d6c3beda37ba83a4962746c43e3a20db46399ec",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BasicTournament_event_WizardElimination"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_unp_event_CEOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_unp_event_CEOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCeo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCeo",
+                    "type": "address"
+                }
+            ],
+            "name": "CEOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x673b537956a28e40aaa8d929fd1b6688c1583dda",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCeo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCeo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "InauguralGateKeeper_event_CEOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_unp_event_CFOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_unp_event_CFOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCfo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCfo",
+                    "type": "address"
+                }
+            ],
+            "name": "CFOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x673b537956a28e40aaa8d929fd1b6688c1583dda",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCfo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCfo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "InauguralGateKeeper_event_CFOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_unp_event_COOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_unp_event_COOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCoo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCoo",
+                    "type": "address"
+                }
+            ],
+            "name": "COOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x673b537956a28e40aaa8d929fd1b6688c1583dda",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCoo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCoo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "InauguralGateKeeper_event_COOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_v1_event_CEOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_v1_event_CEOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCeo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCeo",
+                    "type": "address"
+                }
+            ],
+            "name": "CEOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x68132eb4bfd84b2d6a23ec4fb1b106f5c8574f2d",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCeo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCeo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "InauguralGateKeeper_event_CEOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_v1_event_CFOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_v1_event_CFOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCfo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCfo",
+                    "type": "address"
+                }
+            ],
+            "name": "CFOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x68132eb4bfd84b2d6a23ec4fb1b106f5c8574f2d",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCfo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCfo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "InauguralGateKeeper_event_CFOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_v1_event_COOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/InauguralGateKeeper_v1_event_COOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCoo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCoo",
+                    "type": "address"
+                }
+            ],
+            "name": "COOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x68132eb4bfd84b2d6a23ec4fb1b106f5c8574f2d",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCoo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCoo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "InauguralGateKeeper_event_COOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_Approval.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "approved",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "tokenId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x35b7838dd7507ada69610397a85310ae0abd5034",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "approved",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_ApprovalForAll.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_ApprovalForAll.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "approved",
+                    "type": "bool"
+                }
+            ],
+            "name": "ApprovalForAll",
+            "type": "event"
+        },
+        "contract_address": "0x35b7838dd7507ada69610397a85310ae0abd5034",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "approved",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_ApprovalForAll"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_CEOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_CEOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCeo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCeo",
+                    "type": "address"
+                }
+            ],
+            "name": "CEOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x35b7838dd7507ada69610397a85310ae0abd5034",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCeo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCeo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_CEOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_CFOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_CFOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCfo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCfo",
+                    "type": "address"
+                }
+            ],
+            "name": "CFOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x35b7838dd7507ada69610397a85310ae0abd5034",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCfo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCfo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_CFOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_COOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_COOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCoo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCoo",
+                    "type": "address"
+                }
+            ],
+            "name": "COOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x35b7838dd7507ada69610397a85310ae0abd5034",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCoo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCoo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_COOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_MetadataSet.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_MetadataSet.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "wizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "metadata",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "MetadataSet",
+            "type": "event"
+        },
+        "contract_address": "0x35b7838dd7507ada69610397a85310ae0abd5034",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "metadata",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_MetadataSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_SeriesClose.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_SeriesClose.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "seriesIndex",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SeriesClose",
+            "type": "event"
+        },
+        "contract_address": "0x35b7838dd7507ada69610397a85310ae0abd5034",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "seriesIndex",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_SeriesClose"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_SeriesOpen.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_SeriesOpen.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "seriesIndex",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "name": "reservedIds",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SeriesOpen",
+            "type": "event"
+        },
+        "contract_address": "0x35b7838dd7507ada69610397a85310ae0abd5034",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "seriesIndex",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reservedIds",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_SeriesOpen"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_Transfer.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "tokenId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x35b7838dd7507ada69610397a85310ae0abd5034",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_WizardAffinityAssigned.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_WizardAffinityAssigned.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "affinity",
+                    "type": "uint8"
+                }
+            ],
+            "name": "WizardAffinityAssigned",
+            "type": "event"
+        },
+        "contract_address": "0x35b7838dd7507ada69610397a85310ae0abd5034",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "affinity",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_WizardAffinityAssigned"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_WizardConjured.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_unp_event_WizardConjured.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "affinity",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "name": "innatePower",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WizardConjured",
+            "type": "event"
+        },
+        "contract_address": "0x35b7838dd7507ada69610397a85310ae0abd5034",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "affinity",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "innatePower",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_WizardConjured"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_Approval.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "approved",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "tokenId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x0d8c864da1985525e0af0acbeef6562881827bd5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "approved",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_ApprovalForAll.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_ApprovalForAll.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "approved",
+                    "type": "bool"
+                }
+            ],
+            "name": "ApprovalForAll",
+            "type": "event"
+        },
+        "contract_address": "0x0d8c864da1985525e0af0acbeef6562881827bd5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "approved",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_ApprovalForAll"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_CEOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_CEOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCeo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCeo",
+                    "type": "address"
+                }
+            ],
+            "name": "CEOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x0d8c864da1985525e0af0acbeef6562881827bd5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCeo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCeo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_CEOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_CFOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_CFOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCfo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCfo",
+                    "type": "address"
+                }
+            ],
+            "name": "CFOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x0d8c864da1985525e0af0acbeef6562881827bd5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCfo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCfo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_CFOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_COOTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_COOTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "previousCoo",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newCoo",
+                    "type": "address"
+                }
+            ],
+            "name": "COOTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x0d8c864da1985525e0af0acbeef6562881827bd5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousCoo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCoo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_COOTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_MetadataSet.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_MetadataSet.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "wizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "metadata",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "MetadataSet",
+            "type": "event"
+        },
+        "contract_address": "0x0d8c864da1985525e0af0acbeef6562881827bd5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "metadata",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_MetadataSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_SeriesClose.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_SeriesClose.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "seriesIndex",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SeriesClose",
+            "type": "event"
+        },
+        "contract_address": "0x0d8c864da1985525e0af0acbeef6562881827bd5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "seriesIndex",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_SeriesClose"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_SeriesOpen.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_SeriesOpen.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "seriesIndex",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "name": "reservedIds",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SeriesOpen",
+            "type": "event"
+        },
+        "contract_address": "0x0d8c864da1985525e0af0acbeef6562881827bd5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "seriesIndex",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reservedIds",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_SeriesOpen"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_Transfer.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "tokenId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x0d8c864da1985525e0af0acbeef6562881827bd5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_WizardAffinityAssigned.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_WizardAffinityAssigned.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "affinity",
+                    "type": "uint8"
+                }
+            ],
+            "name": "WizardAffinityAssigned",
+            "type": "event"
+        },
+        "contract_address": "0x0d8c864da1985525e0af0acbeef6562881827bd5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "affinity",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_WizardAffinityAssigned"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_WizardConjured.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardGuild_v1_event_WizardConjured.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wizardId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "affinity",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "name": "innatePower",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WizardConjured",
+            "type": "event"
+        },
+        "contract_address": "0x0d8c864da1985525e0af0acbeef6562881827bd5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "wizardId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "affinity",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "innatePower",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardGuild_event_WizardConjured"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_Approval.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "approved",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "tokenId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x2f4bdafb22bd92aa7b7552d270376de8edccbc1e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "approved",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardPresale_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_ApprovalForAll.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_ApprovalForAll.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "approved",
+                    "type": "bool"
+                }
+            ],
+            "name": "ApprovalForAll",
+            "type": "event"
+        },
+        "contract_address": "0x2f4bdafb22bd92aa7b7552d270376de8edccbc1e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "approved",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardPresale_event_ApprovalForAll"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_StartBlockChanged.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_StartBlockChanged.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldStartBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "newStartBlock",
+                    "type": "uint256"
+                }
+            ],
+            "name": "StartBlockChanged",
+            "type": "event"
+        },
+        "contract_address": "0x2f4bdafb22bd92aa7b7552d270376de8edccbc1e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldStartBlock",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newStartBlock",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardPresale_event_StartBlockChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_Transfer.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "tokenId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x2f4bdafb22bd92aa7b7552d270376de8edccbc1e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardPresale_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_WizardAlignmentAssigned.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_WizardAlignmentAssigned.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "tokenId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "element",
+                    "type": "uint8"
+                }
+            ],
+            "name": "WizardAlignmentAssigned",
+            "type": "event"
+        },
+        "contract_address": "0x2f4bdafb22bd92aa7b7552d270376de8edccbc1e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "tokenId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "element",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardPresale_event_WizardAlignmentAssigned"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_WizardSummoned.json
+++ b/dags/resources/stages/parse/table_definitions/cheezewizards/WizardPresale_event_WizardSummoned.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "tokenId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "element",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "name": "power",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WizardSummoned",
+            "type": "event"
+        },
+        "contract_address": "0x2f4bdafb22bd92aa7b7552d270376de8edccbc1e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "cheezewizards",
+        "schema": [
+            {
+                "description": "",
+                "name": "tokenId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "element",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "power",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WizardPresale_event_WizardSummoned"
+    }
+}


### PR DESCRIPTION
Used the Contract Parser: https://contract-parser.d5.ai
Added events for the presale contract, and both unpasteurized and normal tournament contracts.
List of contracts taken from https://dappradar.com/app/1549/cheeze-wizards and integrated with info shared in the official Discord channel by CheezeWizards team.

<img width="801" alt="Screenshot 2020-01-01 at 20 24 30" src="https://user-images.githubusercontent.com/4787777/71645197-d0715a80-2cd4-11ea-8266-0088c556fa14.png">
