### PR TITLE
Aragon events from DAOFactory and Kernel

### DIFF
--- a/dags/resources/stages/parse/table_definitions/aragon/DAOFactory_event_DeployDAO.json
+++ b/dags/resources/stages/parse/table_definitions/aragon/DAOFactory_event_DeployDAO.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "dao",
+                    "type": "address"
+                }
+            ],
+            "name": "DeployDAO",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x595b34c93aa2c2ba0a38daeede629a0dfbdcc559', '0xc29f0599df12eb4cbe1a34354c4bac6d944071d1', '0xb9da44c051c6cc9e04b7e0f95e95d69c6a6d8031'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aragon",
+        "schema": [
+            {
+                "description": "",
+                "name": "dao",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "DAOFactory_event_DeployDAO"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aragon/DAOFactory_event_DeployEVMScriptRegistry.json
+++ b/dags/resources/stages/parse/table_definitions/aragon/DAOFactory_event_DeployEVMScriptRegistry.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "reg",
+                    "type": "address"
+                }
+            ],
+            "name": "DeployEVMScriptRegistry",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x595b34c93aa2c2ba0a38daeede629a0dfbdcc559', '0xc29f0599df12eb4cbe1a34354c4bac6d944071d1', '0xb9da44c051c6cc9e04b7e0f95e95d69c6a6d8031'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aragon",
+        "schema": [
+            {
+                "description": "",
+                "name": "reg",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "DAOFactory_event_DeployEVMScriptRegistry"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aragon/Kernel_event_NewAppProxy.json
+++ b/dags/resources/stages/parse/table_definitions/aragon/Kernel_event_NewAppProxy.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "isUpgradeable",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "name": "appId",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "NewAppProxy",
+            "type": "event"
+        },
+        "contract_address": "select dao from ref('DAOFactory_event_DeployDAO')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aragon",
+        "schema": [
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "isUpgradeable",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "appId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_NewAppProxy"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aragon/Kernel_event_RecoverToVault.json
+++ b/dags/resources/stages/parse/table_definitions/aragon/Kernel_event_RecoverToVault.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "vault",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RecoverToVault",
+            "type": "event"
+        },
+        "contract_address": "select dao from ref('DAOFactory_event_DeployDAO')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aragon",
+        "schema": [
+            {
+                "description": "",
+                "name": "vault",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_RecoverToVault"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aragon/Kernel_event_SetApp.json
+++ b/dags/resources/stages/parse/table_definitions/aragon/Kernel_event_SetApp.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "namespace",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "appId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "app",
+                    "type": "address"
+                }
+            ],
+            "name": "SetApp",
+            "type": "event"
+        },
+        "contract_address": "select dao from ref('DAOFactory_event_DeployDAO')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aragon",
+        "schema": [
+            {
+                "description": "",
+                "name": "namespace",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "appId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "app",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_SetApp"
+    }
+}


### PR DESCRIPTION
Added events from Aragon contracts DAOFactory and Kernel.

DAOFactory produces child contracts which are identified via the `DeployDAO` events.

Kernel events take place in child contracts, and thus uses the `DeployDAO` table to identify the relevant contracts.

Note that the `DAOFactory` makes use of 3 distinct contract addresses since it currently has 3 different versions.