### PR TITLE
Add Nuo Network contracts

### DIFF
--- a/dags/resources/stages/parse/table_definitions/nuo_network/KernelEscrow_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/KernelEscrow_event_LogNote.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "contract_address": "0xaf38668f4719ecf9452dc0300be3f6c83cbf3721",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "sig",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "guy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "foo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "bar",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wad",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fax",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "KernelEscrow_event_LogNote"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/KernelEscrow_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/KernelEscrow_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "contract_address": "0xaf38668f4719ecf9452dc0300be3f6c83cbf3721",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "authority",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "KernelEscrow_event_LogSetAuthority"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/KernelEscrow_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/KernelEscrow_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "contract_address": "0xaf38668f4719ecf9452dc0300be3f6c83cbf3721",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "KernelEscrow_event_LogSetOwner"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/KernelEscrow_event_LogTransfer.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/KernelEscrow_event_LogTransfer.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogTransfer",
+            "type": "event"
+        },
+        "contract_address": "0xaf38668f4719ecf9452dc0300be3f6c83cbf3721",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "KernelEscrow_event_LogTransfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/KernelEscrow_event_LogTransferFromAccount.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/KernelEscrow_event_LogTransferFromAccount.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogTransferFromAccount",
+            "type": "event"
+        },
+        "contract_address": "0xaf38668f4719ecf9452dc0300be3f6c83cbf3721",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "KernelEscrow_event_LogTransferFromAccount"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogError.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogError.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "methodSig",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "name": "errMsg",
+                    "type": "string"
+                }
+            ],
+            "name": "LogError",
+            "type": "event"
+        },
+        "contract_address": "0x0f99be6639b1ddfbedf319b4de67e558a41aa6ea",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "methodSig",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "errMsg",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_LogError"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogErrorWithHintAddress.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogErrorWithHintAddress.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "addressValue",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "methodSig",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "name": "errMsg",
+                    "type": "string"
+                }
+            ],
+            "name": "LogErrorWithHintAddress",
+            "type": "event"
+        },
+        "contract_address": "0x0f99be6639b1ddfbedf319b4de67e558a41aa6ea",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "addressValue",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "methodSig",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "errMsg",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_LogErrorWithHintAddress"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogErrorWithHintBytes32.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogErrorWithHintBytes32.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "bytes32Value",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "methodSig",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "name": "errMsg",
+                    "type": "string"
+                }
+            ],
+            "name": "LogErrorWithHintBytes32",
+            "type": "event"
+        },
+        "contract_address": "0x0f99be6639b1ddfbedf319b4de67e558a41aa6ea",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "bytes32Value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "methodSig",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "errMsg",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_LogErrorWithHintBytes32"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogNote.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "contract_address": "0x0f99be6639b1ddfbedf319b4de67e558a41aa6ea",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "sig",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "guy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "foo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "bar",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wad",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fax",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_LogNote"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogOrderCreated.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogOrderCreated.json
@@ -1,0 +1,121 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "principalToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "collateralToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "byUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "principalAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "collateralAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "premium",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "expirationTimestamp",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogOrderCreated",
+            "type": "event"
+        },
+        "contract_address": "0x0f99be6639b1ddfbedf319b4de67e558a41aa6ea",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "principalToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateralToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "byUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "principalAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateralAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "premium",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "expirationTimestamp",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_LogOrderCreated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogOrderDefaulted.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogOrderDefaulted.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "reason",
+                    "type": "string"
+                }
+            ],
+            "name": "LogOrderDefaulted",
+            "type": "event"
+        },
+        "contract_address": "0x0f99be6639b1ddfbedf319b4de67e558a41aa6ea",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reason",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_LogOrderDefaulted"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogOrderRepaid.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogOrderRepaid.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "valueRepaid",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogOrderRepaid",
+            "type": "event"
+        },
+        "contract_address": "0x0f99be6639b1ddfbedf319b4de67e558a41aa6ea",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "valueRepaid",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_LogOrderRepaid"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "contract_address": "0x0f99be6639b1ddfbedf319b4de67e558a41aa6ea",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "authority",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_LogSetAuthority"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Kernel_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "contract_address": "0x0f99be6639b1ddfbedf319b4de67e558a41aa6ea",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Kernel_event_LogSetOwner"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/ReserveEscrow_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/ReserveEscrow_event_LogNote.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "contract_address": "0x802275979b020f0ec871c5ec1db6e412b72ff20b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "sig",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "guy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "foo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "bar",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wad",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fax",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ReserveEscrow_event_LogNote"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/ReserveEscrow_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/ReserveEscrow_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "contract_address": "0x802275979b020f0ec871c5ec1db6e412b72ff20b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "authority",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ReserveEscrow_event_LogSetAuthority"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/ReserveEscrow_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/ReserveEscrow_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "contract_address": "0x802275979b020f0ec871c5ec1db6e412b72ff20b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ReserveEscrow_event_LogSetOwner"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/ReserveEscrow_event_LogTransfer.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/ReserveEscrow_event_LogTransfer.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogTransfer",
+            "type": "event"
+        },
+        "contract_address": "0x802275979b020f0ec871c5ec1db6e412b72ff20b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ReserveEscrow_event_LogTransfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/ReserveEscrow_event_LogTransferFromAccount.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/ReserveEscrow_event_LogTransferFromAccount.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogTransferFromAccount",
+            "type": "event"
+        },
+        "contract_address": "0x802275979b020f0ec871c5ec1db6e412b72ff20b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ReserveEscrow_event_LogTransferFromAccount"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogError.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogError.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "methodSig",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "name": "errMsg",
+                    "type": "string"
+                }
+            ],
+            "name": "LogError",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "methodSig",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "errMsg",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogError"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogErrorWithHintAddress.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogErrorWithHintAddress.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "addressValue",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "methodSig",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "name": "errMsg",
+                    "type": "string"
+                }
+            ],
+            "name": "LogErrorWithHintAddress",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "addressValue",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "methodSig",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "errMsg",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogErrorWithHintAddress"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogErrorWithHintBytes32.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogErrorWithHintBytes32.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "bytes32Value",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "methodSig",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "name": "errMsg",
+                    "type": "string"
+                }
+            ],
+            "name": "LogErrorWithHintBytes32",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "bytes32Value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "methodSig",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "errMsg",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogErrorWithHintBytes32"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogLock.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogLock.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "profit",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "loss",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "by",
+                    "type": "address"
+                }
+            ],
+            "name": "LogLock",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "profit",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "loss",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "by",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogLock"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogLockSurplus.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogLockSurplus.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "forToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogLockSurplus",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "forToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogLockSurplus"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogNote.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogNote.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": true,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sig",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": true,
+                    "name": "guy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "foo",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "bar",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "wad",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fax",
+                    "type": "bytes"
+                }
+            ],
+            "name": "LogNote",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "sig",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "guy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "foo",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "bar",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wad",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fax",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogNote"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogOrderCancelled.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogOrderCancelled.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "by",
+                    "type": "address"
+                }
+            ],
+            "name": "LogOrderCancelled",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "by",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogOrderCancelled"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogOrderCreated.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogOrderCreated.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "byUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "expirationTimestamp",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogOrderCreated",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "byUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "expirationTimestamp",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogOrderCreated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogOrderCumulativeUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogOrderCumulativeUpdated.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "updatedTill",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogOrderCumulativeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "updatedTill",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogOrderCumulativeUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogRelease.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogRelease.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "by",
+                    "type": "address"
+                }
+            ],
+            "name": "LogRelease",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "by",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogRelease"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogReserveValuesUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogReserveValuesUpdated.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "updatedTill",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "reserve",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "profit",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "loss",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogReserveValuesUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "updatedTill",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "profit",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "loss",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogReserveValuesUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogSetAuthority.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogSetAuthority.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "authority",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetAuthority",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "authority",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogSetAuthority"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogSetOwner.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogSetOwner.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSetOwner",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogSetOwner"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogTransferSurplus.json
+++ b/dags/resources/stages/parse/table_definitions/nuo_network/Reserve_event_LogTransferSurplus.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "forToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogTransferSurplus",
+            "type": "event"
+        },
+        "contract_address": "0x64d14595152b430cf6940da15c6e39545c7c5b7e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "nuo_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "forToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Reserve_event_LogTransferSurplus"
+    }
+}


### PR DESCRIPTION
Fixes #49

Adds the following Nuo Network contracts to the log parser:

```
Kernel
0x0f99be6639b1ddfbedf319b4de67e558a41aa6ea

Reserve
0x64d14595152b430cf6940da15c6e39545c7c5b7e

ReserveEscrow
0x802275979b020f0ec871c5ec1db6e412b72ff20b

KernelEscrow
0xaf38668f4719ecf9452dc0300be3f6c83cbf3721
```