### PR TITLE
Add Kyber's FeeBurner contract

### DIFF
--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_AdminClaimed.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_AdminClaimed.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "newAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "previousAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "AdminClaimed",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "newAdmin",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "previousAdmin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_AdminClaimed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_AlerterAdded.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_AlerterAdded.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "newAlerter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "isAdd",
+                    "type": "bool"
+                }
+            ],
+            "name": "AlerterAdded",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "newAlerter",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "isAdd",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_AlerterAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_AssignBurnFees.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_AssignBurnFees.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "burnFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AssignBurnFees",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "burnFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_AssignBurnFees"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_AssignFeeToWallet.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_AssignFeeToWallet.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "wallet",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "walletFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AssignFeeToWallet",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wallet",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "walletFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_AssignFeeToWallet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_BurnAssignedFees.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_BurnAssignedFees.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "quantity",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BurnAssignedFees",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "quantity",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_BurnAssignedFees"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_EtherWithdraw.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_EtherWithdraw.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "sendTo",
+                    "type": "address"
+                }
+            ],
+            "name": "EtherWithdraw",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sendTo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_EtherWithdraw"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_KNCRateSet.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_KNCRateSet.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "ethToKncRatePrecision",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "kyberEthKnc",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "kyberKncEth",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "updater",
+                    "type": "address"
+                }
+            ],
+            "name": "KNCRateSet",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "ethToKncRatePrecision",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "kyberEthKnc",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "kyberKncEth",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "updater",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_KNCRateSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_OperatorAdded.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_OperatorAdded.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "newOperator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "isAdd",
+                    "type": "bool"
+                }
+            ],
+            "name": "OperatorAdded",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "newOperator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "isAdd",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_OperatorAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_ReserveDataSet.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_ReserveDataSet.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeInBps",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "kncWallet",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveDataSet",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeInBps",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "kncWallet",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_ReserveDataSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_SendTaxFee.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_SendTaxFee.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "taxWallet",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "quantity",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SendTaxFee",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "taxWallet",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "quantity",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_SendTaxFee"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_SendWalletFees.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_SendWalletFees.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "wallet",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "sender",
+                    "type": "address"
+                }
+            ],
+            "name": "SendWalletFees",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "wallet",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_SendWalletFees"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_TaxFeesSet.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_TaxFeesSet.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "feesInBps",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TaxFeesSet",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "feesInBps",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_TaxFeesSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_TaxWalletSet.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_TaxWalletSet.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "taxWallet",
+                    "type": "address"
+                }
+            ],
+            "name": "TaxWalletSet",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "taxWallet",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_TaxWalletSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_TokenWithdraw.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_TokenWithdraw.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "sendTo",
+                    "type": "address"
+                }
+            ],
+            "name": "TokenWithdraw",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sendTo",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_TokenWithdraw"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_TransferAdminPending.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_TransferAdminPending.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "pendingAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "TransferAdminPending",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "pendingAdmin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_TransferAdminPending"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_WalletFeesSet.json
+++ b/dags/resources/stages/parse/table_definitions/kyber/FeeBurner_event_WalletFeesSet.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "wallet",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "feesInBps",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WalletFeesSet",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x8007aa43792a392b221dc091bdb2191e5ff626d1', '0x52166528fcc12681af996e409ee3a421a4e128a3', '0xed4f53268bfdff39b36e8786247ba3a02cf34b04', '0x07f6e905f2a1559cd9fd43cb92f8a1062a3ca706'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "kyber",
+        "schema": [
+            {
+                "description": "",
+                "name": "wallet",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feesInBps",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FeeBurner_event_WalletFeesSet"
+    }
+}


### PR DESCRIPTION
Currently we can't calculate how much KNC is burnt from our events.

This PR adds parsing for Kyber's FeeBurner contract, documented here: https://developer.kyber.network/docs/Integrations-ContractEvents/#feeburnerdocsenvironments-mainnetfeeburner

Used [Contract Parser](http://contract-parser.d5.ai/) but manually updated `contract_address` to include all versions of the contract.