### PR TITLE
Use ethers.js for parsing logs

### DIFF
--- a/dags/ethereumetl_airflow/parse.py
+++ b/dags/ethereumetl_airflow/parse.py
@@ -137,10 +137,15 @@ def abi_to_method_selector(abi):
 
 def create_struct_string_from_schema(schema):
     def get_type(field):
-        if field.get('mode') == 'REPEATED':
-            return 'ARRAY<{type}>'.format(type=field.get('type'))
+        if field.get('type') == 'RECORD':
+            type_str = 'STRUCT<{struct_string}>'.format(struct_string=create_struct_string_from_schema(field.get('fields')))
         else:
-            return field.get('type')
+            type_str = field.get('type')
+
+        if field.get('mode') == 'REPEATED':
+            type_str = 'ARRAY<{type}>'.format(type=type_str)
+
+        return type_str
 
     def get_field_def(field):
         return '`' + field.get('name') + '` ' + get_type(field)

--- a/dags/resources/stages/parse/sqls/parse_logs.sql
+++ b/dags/resources/stages/parse/sqls/parse_logs.sql
@@ -1,12 +1,43 @@
 CREATE TEMP FUNCTION
-  PARSE_LOG(data STRING, topics ARRAY<STRING>)
-  RETURNS STRUCT<{{params.struct_fields}}>
-  LANGUAGE js AS """
-    var parsedEvent = {{params.abi}}
-    return abi.decodeEvent(parsedEvent, data, topics, false);
+    PARSE_LOG(data STRING, topics ARRAY<STRING>)
+    RETURNS STRUCT<{{params.struct_fields}}>
+    LANGUAGE js AS """
+    var abi = {{params.abi}}
+
+    var interface_instance = new ethers.utils.Interface([abi]);
+
+    var parsedLog = interface_instance.parseLog({topics: topics, data: data});
+
+    var parsedValues = parsedLog.values;
+
+    var transformParams = function(params, abiInputs) {
+        var result = {};
+        if (params && params.length >= abiInputs.length) {
+            for (var i = 0; i < abiInputs.length; i++) {
+                var paramName = abiInputs[i].name;
+                var paramValue = params[i];
+                if (abiInputs[i].type === 'address' && typeof paramValue === 'string') {
+                    // For consistency all addresses are lower-cased.
+                    paramValue = paramValue.toLowerCase();
+                }
+                if (ethers.utils.Interface.isIndexed(paramValue)) {
+                    paramValue = paramValue.hash;
+                }
+                if (abiInputs[i].type === 'tuple' && 'components' in abiInputs[i]) {
+                    paramValue = transformParams(paramValue, abiInputs[i].components)
+                }
+                result[paramName] = paramValue;
+            }
+        }
+        return result;
+    };
+
+    var result = transformParams(parsedValues, abi.inputs);
+
+    return result;
 """
 OPTIONS
-  ( library="https://storage.googleapis.com/ethlab-183014.appspot.com/ethjs-abi.js" );
+  ( library="gs://blockchain-etl-bigquery/ethers.js" );
 
 WITH parsed_logs AS
 (SELECT

--- a/dags/resources/stages/parse/table_definitions/dydx/SoloMargin_event_LogTrade.json
+++ b/dags/resources/stages/parse/table_definitions/dydx/SoloMargin_event_LogTrade.json
@@ -1,0 +1,371 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x1e0447b19bb6ecfdae1e4ae1694b0c3659614e4e",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "takerAccountOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "takerAccountNumber",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "name": "makerAccountOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "makerAccountNumber",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "inputMarket",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "outputMarket",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "name": "sign",
+                                    "type": "bool"
+                                },
+                                {
+                                    "name": "value",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "name": "deltaWei",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "name": "sign",
+                                    "type": "bool"
+                                },
+                                {
+                                    "name": "value",
+                                    "type": "uint128"
+                                }
+                            ],
+                            "name": "newPar",
+                            "type": "tuple"
+                        }
+                    ],
+                    "indexed": false,
+                    "name": "takerInputUpdate",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "name": "sign",
+                                    "type": "bool"
+                                },
+                                {
+                                    "name": "value",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "name": "deltaWei",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "name": "sign",
+                                    "type": "bool"
+                                },
+                                {
+                                    "name": "value",
+                                    "type": "uint128"
+                                }
+                            ],
+                            "name": "newPar",
+                            "type": "tuple"
+                        }
+                    ],
+                    "indexed": false,
+                    "name": "takerOutputUpdate",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "name": "sign",
+                                    "type": "bool"
+                                },
+                                {
+                                    "name": "value",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "name": "deltaWei",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "name": "sign",
+                                    "type": "bool"
+                                },
+                                {
+                                    "name": "value",
+                                    "type": "uint128"
+                                }
+                            ],
+                            "name": "newPar",
+                            "type": "tuple"
+                        }
+                    ],
+                    "indexed": false,
+                    "name": "makerInputUpdate",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "name": "sign",
+                                    "type": "bool"
+                                },
+                                {
+                                    "name": "value",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "name": "deltaWei",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "name": "sign",
+                                    "type": "bool"
+                                },
+                                {
+                                    "name": "value",
+                                    "type": "uint128"
+                                }
+                            ],
+                            "name": "newPar",
+                            "type": "tuple"
+                        }
+                    ],
+                    "indexed": false,
+                    "name": "makerOutputUpdate",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "name": "autoTrader",
+                    "type": "address"
+                }
+            ],
+            "name": "LogTrade",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "airswap",
+        "table_name": "AirSwapExchange_event_Canceled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "takerAccountOwner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerAccountNumber",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "makerAccountOwner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "makerAccountNumber",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "inputMarket",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "outputMarket",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerInputUpdate",
+                "description": "",
+                "type": "RECORD",
+                "fields": [
+                    {
+                        "name": "deltaWei",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "sign",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "value",
+                                "type": "STRING"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "newPar",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "sign",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "value",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "takerOutputUpdate",
+                "description": "",
+                "type": "RECORD",
+                "fields": [
+                    {
+                        "name": "deltaWei",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "sign",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "value",
+                                "type": "STRING"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "newPar",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "sign",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "value",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "makerInputUpdate",
+                "description": "",
+                "type": "RECORD",
+                "fields": [
+                    {
+                        "name": "deltaWei",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "sign",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "value",
+                                "type": "STRING"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "newPar",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "sign",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "value",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "makerOutputUpdate",
+                "description": "",
+                "type": "RECORD",
+                "fields": [
+                    {
+                        "name": "deltaWei",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "sign",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "value",
+                                "type": "STRING"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "newPar",
+                        "type": "RECORD",
+                        "fields": [
+                            {
+                                "name": "sign",
+                                "type": "STRING"
+                            },
+                            {
+                                "name": "value",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "autoTrader",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/dydx/SoloMargin_event_LogTrade.json
+++ b/dags/resources/stages/parse/table_definitions/dydx/SoloMargin_event_LogTrade.json
@@ -187,8 +187,8 @@
         "field_mapping": {}
     },
     "table": {
-        "dataset_name": "airswap",
-        "table_name": "AirSwapExchange_event_Canceled",
+        "dataset_name": "dydx",
+        "table_name": "SoloMargin_event_LogTrade",
         "table_description": "",
         "schema": [
             {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 apache-airflow[gcp]==1.10.3
-ethereum-etl==1.3.1
+ethereum-etl==1.4.1
 google-cloud-bigquery
 pytest==5.4.1

--- a/tests/ethereumetl_airflow/test_parse.py
+++ b/tests/ethereumetl_airflow/test_parse.py
@@ -18,6 +18,8 @@ table_definitions_folder = 'dags/resources/stages/parse/table_definitions'
 @pytest.mark.parametrize("table_definition_file", [
     ('ens/Registrar0_event_NewBid.json'),
     ('uniswap/Uniswap_event_AddLiquidity.json'),
+    ('dydx/SoloMargin_event_LogTrade.json'),
+    ('idex/Exchange_call_trade.json'),
 ])
 def test_create_or_update_table_from_table_definition(table_definition_file):
     bigquery_client = MockBigqueryClient()

--- a/tests/resources/ethereumetl_airflow/test_parse/expected_dydx_SoloMargin_event_LogTrade.json.sql
+++ b/tests/resources/ethereumetl_airflow/test_parse/expected_dydx_SoloMargin_event_LogTrade.json.sql
@@ -1,0 +1,79 @@
+CREATE TEMP FUNCTION
+    PARSE_LOG(data STRING, topics ARRAY<STRING>)
+    RETURNS STRUCT<`takerAccountOwner` STRING, `takerAccountNumber` STRING, `makerAccountOwner` STRING, `makerAccountNumber` STRING, `inputMarket` STRING, `outputMarket` STRING, `takerInputUpdate` STRUCT<`deltaWei` STRUCT<`sign` STRING, `value` STRING>, `newPar` STRUCT<`sign` STRING, `value` STRING>>, `takerOutputUpdate` STRUCT<`deltaWei` STRUCT<`sign` STRING, `value` STRING>, `newPar` STRUCT<`sign` STRING, `value` STRING>>, `makerInputUpdate` STRUCT<`deltaWei` STRUCT<`sign` STRING, `value` STRING>, `newPar` STRUCT<`sign` STRING, `value` STRING>>, `makerOutputUpdate` STRUCT<`deltaWei` STRUCT<`sign` STRING, `value` STRING>, `newPar` STRUCT<`sign` STRING, `value` STRING>>, `autoTrader` STRING>
+    LANGUAGE js AS """
+    var abi = {"anonymous": false, "inputs": [{"indexed": true, "name": "takerAccountOwner", "type": "address"}, {"indexed": false, "name": "takerAccountNumber", "type": "uint256"}, {"indexed": true, "name": "makerAccountOwner", "type": "address"}, {"indexed": false, "name": "makerAccountNumber", "type": "uint256"}, {"indexed": false, "name": "inputMarket", "type": "uint256"}, {"indexed": false, "name": "outputMarket", "type": "uint256"}, {"components": [{"components": [{"name": "sign", "type": "bool"}, {"name": "value", "type": "uint256"}], "name": "deltaWei", "type": "tuple"}, {"components": [{"name": "sign", "type": "bool"}, {"name": "value", "type": "uint128"}], "name": "newPar", "type": "tuple"}], "indexed": false, "name": "takerInputUpdate", "type": "tuple"}, {"components": [{"components": [{"name": "sign", "type": "bool"}, {"name": "value", "type": "uint256"}], "name": "deltaWei", "type": "tuple"}, {"components": [{"name": "sign", "type": "bool"}, {"name": "value", "type": "uint128"}], "name": "newPar", "type": "tuple"}], "indexed": false, "name": "takerOutputUpdate", "type": "tuple"}, {"components": [{"components": [{"name": "sign", "type": "bool"}, {"name": "value", "type": "uint256"}], "name": "deltaWei", "type": "tuple"}, {"components": [{"name": "sign", "type": "bool"}, {"name": "value", "type": "uint128"}], "name": "newPar", "type": "tuple"}], "indexed": false, "name": "makerInputUpdate", "type": "tuple"}, {"components": [{"components": [{"name": "sign", "type": "bool"}, {"name": "value", "type": "uint256"}], "name": "deltaWei", "type": "tuple"}, {"components": [{"name": "sign", "type": "bool"}, {"name": "value", "type": "uint128"}], "name": "newPar", "type": "tuple"}], "indexed": false, "name": "makerOutputUpdate", "type": "tuple"}, {"indexed": false, "name": "autoTrader", "type": "address"}], "name": "LogTrade", "type": "event"}
+
+    var interface_instance = new ethers.utils.Interface([abi]);
+
+    var parsedLog = interface_instance.parseLog({topics: topics, data: data});
+
+    var parsedValues = parsedLog.values;
+
+    var transformParams = function(params, abiInputs) {
+        var result = {};
+        if (params && params.length >= abiInputs.length) {
+            for (var i = 0; i < abiInputs.length; i++) {
+                var paramName = abiInputs[i].name;
+                var paramValue = params[i];
+                if (abiInputs[i].type === 'address' && typeof paramValue === 'string') {
+                    // For consistency all addresses are lower-cased.
+                    paramValue = paramValue.toLowerCase();
+                }
+                if (ethers.utils.Interface.isIndexed(paramValue)) {
+                    paramValue = paramValue.hash;
+                }
+                if (abiInputs[i].type === 'tuple' && 'components' in abiInputs[i]) {
+                    paramValue = transformParams(paramValue, abiInputs[i].components)
+                }
+                result[paramName] = paramValue;
+            }
+        }
+        return result;
+    };
+
+    var result = transformParams(parsedValues, abi.inputs);
+
+    return result;
+"""
+OPTIONS
+  ( library="gs://blockchain-etl-bigquery/ethers.js" );
+
+WITH parsed_logs AS
+(SELECT
+    logs.block_timestamp AS block_timestamp
+    ,logs.block_number AS block_number
+    ,logs.transaction_hash AS transaction_hash
+    ,logs.log_index AS log_index
+    ,logs.address AS contract_address
+    ,PARSE_LOG(logs.data, logs.topics) AS parsed
+FROM `bigquery-public-data.crypto_ethereum.logs` AS logs
+WHERE address in (
+
+    '0x1e0447b19bb6ecfdae1e4ae1694b0c3659614e4e'
+
+  )
+  AND topics[SAFE_OFFSET(0)] = '0x54d4cc60cf7d570631cc1a58942812cb0fc461713613400f56932040c3497d19'
+
+  AND DATE(block_timestamp) <= '2020-01-01'
+
+  )
+SELECT
+     block_timestamp
+     ,block_number
+     ,transaction_hash
+     ,log_index
+     ,contract_address
+
+    ,parsed.takerAccountOwner AS `takerAccountOwner`
+    ,parsed.takerAccountNumber AS `takerAccountNumber`
+    ,parsed.makerAccountOwner AS `makerAccountOwner`
+    ,parsed.makerAccountNumber AS `makerAccountNumber`
+    ,parsed.inputMarket AS `inputMarket`
+    ,parsed.outputMarket AS `outputMarket`
+    ,parsed.takerInputUpdate AS `takerInputUpdate`
+    ,parsed.takerOutputUpdate AS `takerOutputUpdate`
+    ,parsed.makerInputUpdate AS `makerInputUpdate`
+    ,parsed.makerOutputUpdate AS `makerOutputUpdate`
+    ,parsed.autoTrader AS `autoTrader`
+FROM parsed_logs

--- a/tests/resources/ethereumetl_airflow/test_parse/expected_ens_Registrar0_event_NewBid.json.sql
+++ b/tests/resources/ethereumetl_airflow/test_parse/expected_ens_Registrar0_event_NewBid.json.sql
@@ -1,12 +1,43 @@
 CREATE TEMP FUNCTION
-  PARSE_LOG(data STRING, topics ARRAY<STRING>)
-  RETURNS STRUCT<`hash` STRING, `bidder` STRING, `deposit` STRING>
-  LANGUAGE js AS """
-    var parsedEvent = {"anonymous": false, "inputs": [{"indexed": true, "name": "hash", "type": "bytes32"}, {"indexed": true, "name": "bidder", "type": "address"}, {"indexed": false, "name": "deposit", "type": "uint256"}], "name": "NewBid", "type": "event"}
-    return abi.decodeEvent(parsedEvent, data, topics, false);
+    PARSE_LOG(data STRING, topics ARRAY<STRING>)
+    RETURNS STRUCT<`hash` STRING, `bidder` STRING, `deposit` STRING>
+    LANGUAGE js AS """
+    var abi = {"anonymous": false, "inputs": [{"indexed": true, "name": "hash", "type": "bytes32"}, {"indexed": true, "name": "bidder", "type": "address"}, {"indexed": false, "name": "deposit", "type": "uint256"}], "name": "NewBid", "type": "event"}
+
+    var interface_instance = new ethers.utils.Interface([abi]);
+
+    var parsedLog = interface_instance.parseLog({topics: topics, data: data});
+
+    var parsedValues = parsedLog.values;
+
+    var transformParams = function(params, abiInputs) {
+        var result = {};
+        if (params && params.length >= abiInputs.length) {
+            for (var i = 0; i < abiInputs.length; i++) {
+                var paramName = abiInputs[i].name;
+                var paramValue = params[i];
+                if (abiInputs[i].type === 'address' && typeof paramValue === 'string') {
+                    // For consistency all addresses are lower-cased.
+                    paramValue = paramValue.toLowerCase();
+                }
+                if (ethers.utils.Interface.isIndexed(paramValue)) {
+                    paramValue = paramValue.hash;
+                }
+                if (abiInputs[i].type === 'tuple' && 'components' in abiInputs[i]) {
+                    paramValue = transformParams(paramValue, abiInputs[i].components)
+                }
+                result[paramName] = paramValue;
+            }
+        }
+        return result;
+    };
+
+    var result = transformParams(parsedValues, abi.inputs);
+
+    return result;
 """
 OPTIONS
-  ( library="https://storage.googleapis.com/ethlab-183014.appspot.com/ethjs-abi.js" );
+  ( library="gs://blockchain-etl-bigquery/ethers.js" );
 
 WITH parsed_logs AS
 (SELECT

--- a/tests/resources/ethereumetl_airflow/test_parse/expected_idex_Exchange_call_trade.json.sql
+++ b/tests/resources/ethereumetl_airflow/test_parse/expected_idex_Exchange_call_trade.json.sql
@@ -1,0 +1,66 @@
+CREATE TEMP FUNCTION
+    PARSE_TRACE(data STRING)
+    RETURNS STRUCT<`tradeValues` ARRAY<STRING>, `tradeAddresses` ARRAY<STRING>, `v` ARRAY<STRING>, `rs` ARRAY<STRING>, error STRING>
+    LANGUAGE js AS """
+    var abi = {"constant": false, "inputs": [{"name": "tradeValues", "type": "uint256[8]"}, {"name": "tradeAddresses", "type": "address[4]"}, {"name": "v", "type": "uint8[2]"}, {"name": "rs", "type": "bytes32[4]"}], "name": "trade", "outputs": [{"name": "success", "type": "bool"}], "payable": false, "stateMutability": "nonpayable", "type": "function"};
+    var interface_instance = new ethers.utils.Interface([abi]);
+
+    var result = {};
+    try {
+        var parsedTransaction = interface_instance.parseTransaction({data: data});
+        var parsedArgs = parsedTransaction.args;
+
+        if (parsedArgs && parsedArgs.length >= abi.inputs.length) {
+            for (var i = 0; i < abi.inputs.length; i++) {
+                var paramName = abi.inputs[i].name;
+                var paramValue = parsedArgs[i];
+                if (abi.inputs[i].type === 'address' && typeof paramValue === 'string') {
+                    // For consistency all addresses are lowercase.
+                    paramValue = paramValue.toLowerCase();
+                }
+                result[paramName] = paramValue;
+            }
+        } else {
+            result['error'] = 'Parsed transaction args is empty or has too few values.';
+        }
+    } catch (e) {
+        result['error'] = e.message;
+    }
+
+    return result;
+"""
+OPTIONS
+  ( library="gs://blockchain-etl-bigquery/ethers.js" );
+
+WITH parsed_traces AS
+(SELECT
+    traces.block_timestamp AS block_timestamp
+    ,traces.block_number AS block_number
+    ,traces.transaction_hash AS transaction_hash
+    ,traces.trace_address AS trace_address
+    ,traces.status AS status
+    ,PARSE_TRACE(traces.input) AS parsed
+FROM `bigquery-public-data.crypto_ethereum.traces` AS traces
+WHERE to_address = '0x2a0c0dbecc7e4d658f48e01e3fa353f44050c208'
+  AND STARTS_WITH(traces.input, '0xef343588')
+
+  AND DATE(block_timestamp) <= '2020-01-01'
+
+  )
+SELECT
+     block_timestamp
+     ,block_number
+     ,transaction_hash
+     ,trace_address
+     ,status
+     ,parsed.error AS error
+
+    ,parsed.tradeValues AS `tradeValues`
+
+    ,parsed.tradeAddresses AS `tradeAddresses`
+
+    ,parsed.v AS `v`
+
+    ,parsed.rs AS `rs`
+
+FROM parsed_traces

--- a/tests/resources/ethereumetl_airflow/test_parse/expected_uniswap_Uniswap_event_AddLiquidity.json.sql
+++ b/tests/resources/ethereumetl_airflow/test_parse/expected_uniswap_Uniswap_event_AddLiquidity.json.sql
@@ -1,12 +1,43 @@
 CREATE TEMP FUNCTION
-  PARSE_LOG(data STRING, topics ARRAY<STRING>)
-  RETURNS STRUCT<`provider` STRING, `eth_amount` STRING, `token_amount` STRING>
-  LANGUAGE js AS """
-    var parsedEvent = {"anonymous": false, "inputs": [{"indexed": true, "name": "provider", "type": "address"}, {"indexed": true, "name": "eth_amount", "type": "uint256"}, {"indexed": true, "name": "token_amount", "type": "uint256"}], "name": "AddLiquidity", "type": "event"}
-    return abi.decodeEvent(parsedEvent, data, topics, false);
+    PARSE_LOG(data STRING, topics ARRAY<STRING>)
+    RETURNS STRUCT<`provider` STRING, `eth_amount` STRING, `token_amount` STRING>
+    LANGUAGE js AS """
+    var abi = {"anonymous": false, "inputs": [{"indexed": true, "name": "provider", "type": "address"}, {"indexed": true, "name": "eth_amount", "type": "uint256"}, {"indexed": true, "name": "token_amount", "type": "uint256"}], "name": "AddLiquidity", "type": "event"}
+
+    var interface_instance = new ethers.utils.Interface([abi]);
+
+    var parsedLog = interface_instance.parseLog({topics: topics, data: data});
+
+    var parsedValues = parsedLog.values;
+
+    var transformParams = function(params, abiInputs) {
+        var result = {};
+        if (params && params.length >= abiInputs.length) {
+            for (var i = 0; i < abiInputs.length; i++) {
+                var paramName = abiInputs[i].name;
+                var paramValue = params[i];
+                if (abiInputs[i].type === 'address' && typeof paramValue === 'string') {
+                    // For consistency all addresses are lower-cased.
+                    paramValue = paramValue.toLowerCase();
+                }
+                if (ethers.utils.Interface.isIndexed(paramValue)) {
+                    paramValue = paramValue.hash;
+                }
+                if (abiInputs[i].type === 'tuple' && 'components' in abiInputs[i]) {
+                    paramValue = transformParams(paramValue, abiInputs[i].components)
+                }
+                result[paramName] = paramValue;
+            }
+        }
+        return result;
+    };
+
+    var result = transformParams(parsedValues, abi.inputs);
+
+    return result;
 """
 OPTIONS
-  ( library="https://storage.googleapis.com/ethlab-183014.appspot.com/ethjs-abi.js" );
+  ( library="gs://blockchain-etl-bigquery/ethers.js" );
 
 WITH parsed_logs AS
 (SELECT


### PR DESCRIPTION
ethers.js library is used now for parsing logs, which allows parsing events with tuple parameters. As an example SoloMargin_event_LogTrade.json is provided as well as the test cases with the expected query.