### PR TITLE
Add Multis factory + child events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_Confirmation.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_Confirmation.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "transactionId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Confirmation",
+            "type": "event"
+        },
+        "contract_address": "SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "transactionId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultiSigWalletWithDailyLimit_event_Confirmation"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_DailyLimitChange.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_DailyLimitChange.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "dailyLimit",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DailyLimitChange",
+            "type": "event"
+        },
+        "contract_address": "SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "dailyLimit",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultiSigWalletWithDailyLimit_event_DailyLimitChange"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_Deposit.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposit",
+            "type": "event"
+        },
+        "contract_address": "SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultiSigWalletWithDailyLimit_event_Deposit"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_Execution.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_Execution.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "transactionId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Execution",
+            "type": "event"
+        },
+        "contract_address": "SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "transactionId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultiSigWalletWithDailyLimit_event_Execution"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_ExecutionFailure.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_ExecutionFailure.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "transactionId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ExecutionFailure",
+            "type": "event"
+        },
+        "contract_address": "SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "transactionId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultiSigWalletWithDailyLimit_event_ExecutionFailure"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_OwnerAddition.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_OwnerAddition.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerAddition",
+            "type": "event"
+        },
+        "contract_address": "SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultiSigWalletWithDailyLimit_event_OwnerAddition"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_OwnerRemoval.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_OwnerRemoval.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerRemoval",
+            "type": "event"
+        },
+        "contract_address": "SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultiSigWalletWithDailyLimit_event_OwnerRemoval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_RelayHubChanged.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_RelayHubChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldRelayHub",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newRelayHub",
+                    "type": "address"
+                }
+            ],
+            "name": "RelayHubChanged",
+            "type": "event"
+        },
+        "contract_address": "SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldRelayHub",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newRelayHub",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultiSigWalletWithDailyLimit_event_RelayHubChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_RequirementChange.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_RequirementChange.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "required",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RequirementChange",
+            "type": "event"
+        },
+        "contract_address": "SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "required",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultiSigWalletWithDailyLimit_event_RequirementChange"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_Revocation.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_Revocation.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "transactionId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Revocation",
+            "type": "event"
+        },
+        "contract_address": "SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "transactionId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultiSigWalletWithDailyLimit_event_Revocation"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_Submission.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultiSigWalletWithDailyLimit_event_Submission.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "transactionId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Submission",
+            "type": "event"
+        },
+        "contract_address": "SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "transactionId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultiSigWalletWithDailyLimit_event_Submission"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultisigFactory_event_ContractInstantiation.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultisigFactory_event_ContractInstantiation.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "instantiation",
+                    "type": "address"
+                }
+            ],
+            "name": "ContractInstantiation",
+            "type": "event"
+        },
+        "contract_address": "0x16154f7e9de01e6b39dac3159805e9b1531ee3cf",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "instantiation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultisigFactory_event_ContractInstantiation"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultisigFactory_event_MinterAdded.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultisigFactory_event_MinterAdded.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MinterAdded",
+            "type": "event"
+        },
+        "contract_address": "0x16154f7e9de01e6b39dac3159805e9b1531ee3cf",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultisigFactory_event_MinterAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultisigFactory_event_MinterRemoved.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultisigFactory_event_MinterRemoved.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MinterRemoved",
+            "type": "event"
+        },
+        "contract_address": "0x16154f7e9de01e6b39dac3159805e9b1531ee3cf",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultisigFactory_event_MinterRemoved"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultisigFactory_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultisigFactory_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x16154f7e9de01e6b39dac3159805e9b1531ee3cf",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultisigFactory_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/multis/GSNMultisigFactory_event_RelayHubChanged.json
+++ b/dags/resources/stages/parse/table_definitions/multis/GSNMultisigFactory_event_RelayHubChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldRelayHub",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newRelayHub",
+                    "type": "address"
+                }
+            ],
+            "name": "RelayHubChanged",
+            "type": "event"
+        },
+        "contract_address": "0x16154f7e9de01e6b39dac3159805e9b1531ee3cf",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "multis",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldRelayHub",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newRelayHub",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GSNMultisigFactory_event_RelayHubChanged"
+    }
+}


### PR DESCRIPTION
Used [Contract Parser](https://contract-parser.d5.ai) on `0x58ccd381c5162c6d40f40de03d5d2eb779f87bb6` which is the implementation of this proxy: `0x16154f7e9de01e6b39dac3159805e9b1531ee3cf`.

I then manually replaced the implementation address with the proxy address.

Then for the child contracts I picked one, ran it through the Contract Parser, and then replaced the address field manually with `SELECT instantiation FROM ref('GSNMultisigFactory_event_ContractInstantiation')`.