### PR TITLE
Add GovernorAlpha event parsing

### DIFF
--- a/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_ProposalCanceled.json
+++ b/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_ProposalCanceled.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProposalCanceled",
+            "type": "event"
+        },
+        "contract_address": "0xc0da01a04c3f3e0be433606045bb7017a7323e38",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GovernorAlpha_event_ProposalCanceled"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_ProposalCreated.json
+++ b/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_ProposalCreated.json
@@ -81,22 +81,26 @@
             {
                 "description": "",
                 "name": "targets",
-                "type": "STRING"
+                "type": "STRING",
+                "mode": "REPEATED"
             },
             {
                 "description": "",
                 "name": "values",
-                "type": "STRING"
+                "type": "STRING",
+                "mode": "REPEATED"
             },
             {
                 "description": "",
                 "name": "signatures",
-                "type": "STRING"
+                "type": "STRING",
+                "mode": "REPEATED"
             },
             {
                 "description": "",
                 "name": "calldatas",
-                "type": "STRING"
+                "type": "STRING",
+                "mode": "REPEATED"
             },
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_ProposalCreated.json
+++ b/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_ProposalCreated.json
@@ -1,0 +1,120 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "proposer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address[]",
+                    "name": "targets",
+                    "type": "address[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256[]",
+                    "name": "values",
+                    "type": "uint256[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string[]",
+                    "name": "signatures",
+                    "type": "string[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes[]",
+                    "name": "calldatas",
+                    "type": "bytes[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "startBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "endBlock",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "description",
+                    "type": "string"
+                }
+            ],
+            "name": "ProposalCreated",
+            "type": "event"
+        },
+        "contract_address": "0xc0da01a04c3f3e0be433606045bb7017a7323e38",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proposer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "targets",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "values",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "signatures",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "calldatas",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "startBlock",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "endBlock",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "description",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GovernorAlpha_event_ProposalCreated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_ProposalExecuted.json
+++ b/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_ProposalExecuted.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProposalExecuted",
+            "type": "event"
+        },
+        "contract_address": "0xc0da01a04c3f3e0be433606045bb7017a7323e38",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GovernorAlpha_event_ProposalExecuted"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_ProposalQueued.json
+++ b/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_ProposalQueued.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "eta",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ProposalQueued",
+            "type": "event"
+        },
+        "contract_address": "0xc0da01a04c3f3e0be433606045bb7017a7323e38",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "eta",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GovernorAlpha_event_ProposalQueued"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_VoteCast.json
+++ b/dags/resources/stages/parse/table_definitions/compound/GovernorAlpha_event_VoteCast.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "voter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "proposalId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "support",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "votes",
+                    "type": "uint256"
+                }
+            ],
+            "name": "VoteCast",
+            "type": "event"
+        },
+        "contract_address": "0xc0da01a04c3f3e0be433606045bb7017a7323e38",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "voter",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proposalId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "support",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "votes",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GovernorAlpha_event_VoteCast"
+    }
+}


### PR DESCRIPTION
Used [Contract Parser](https://contract-parser.d5.ai) on `0xc0da01a04c3f3e0be433606045bb7017a7323e38`

See https://compound.finance/governance for more context.

NOTE: there's a `string[]` datatype in there - not 100% sure this will work out of the box.