### PR TITLE
Add events (and some function calls) for BTC tokens

### DIFF
--- a/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_AdminChanged.json
+++ b/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_AdminChanged.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "TaskType",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "class",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "AdminChanged",
+            "type": "event"
+        },
+        "contract_address": "0x0316eb71485b0ab14103307bf65a021042c6d380",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "hbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "TaskType",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "class",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldAddress",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "HBTCToken_event_AdminChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_AdminRequiredNumChanged.json
+++ b/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_AdminRequiredNumChanged.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "TaskType",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "class",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "previousNum",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "requiredNum",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AdminRequiredNumChanged",
+            "type": "event"
+        },
+        "contract_address": "0x0316eb71485b0ab14103307bf65a021042c6d380",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "hbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "TaskType",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "class",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "previousNum",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "requiredNum",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "HBTCToken_event_AdminRequiredNumChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_AdminTaskDropped.json
+++ b/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_AdminTaskDropped.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "taskHash",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "AdminTaskDropped",
+            "type": "event"
+        },
+        "contract_address": "0x0316eb71485b0ab14103307bf65a021042c6d380",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "hbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "taskHash",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "HBTCToken_event_AdminTaskDropped"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x0316eb71485b0ab14103307bf65a021042c6d380",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "hbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "HBTCToken_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Burned.json
+++ b/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Burned.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "proof",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "btcAddress",
+                    "type": "string"
+                }
+            ],
+            "name": "Burned",
+            "type": "event"
+        },
+        "contract_address": "0x0316eb71485b0ab14103307bf65a021042c6d380",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "hbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proof",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "btcAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "HBTCToken_event_Burned"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Burning.json
+++ b/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Burning.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "proof",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "btcAddress",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "burner",
+                    "type": "address"
+                }
+            ],
+            "name": "Burning",
+            "type": "event"
+        },
+        "contract_address": "0x0316eb71485b0ab14103307bf65a021042c6d380",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "hbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proof",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "btcAddress",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "burner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "HBTCToken_event_Burning"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Minted.json
+++ b/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Minted.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "proof",
+                    "type": "string"
+                }
+            ],
+            "name": "Minted",
+            "type": "event"
+        },
+        "contract_address": "0x0316eb71485b0ab14103307bf65a021042c6d380",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "hbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proof",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "HBTCToken_event_Minted"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Minting.json
+++ b/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Minting.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "proof",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                }
+            ],
+            "name": "Minting",
+            "type": "event"
+        },
+        "contract_address": "0x0316eb71485b0ab14103307bf65a021042c6d380",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "hbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proof",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "minter",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "HBTCToken_event_Minting"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_PauseChangedTo.json
+++ b/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_PauseChangedTo.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "pauseState",
+                    "type": "bool"
+                }
+            ],
+            "name": "PauseChangedTo",
+            "type": "event"
+        },
+        "contract_address": "0x0316eb71485b0ab14103307bf65a021042c6d380",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "hbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "pauseState",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "HBTCToken_event_PauseChangedTo"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/hbtc/HBTCToken_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x0316eb71485b0ab14103307bf65a021042c6d380",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "hbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "HBTCToken_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Approval.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_AuthorizedOperator.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_AuthorizedOperator.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "tokenHolder",
+                    "type": "address"
+                }
+            ],
+            "name": "AuthorizedOperator",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenHolder",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_AuthorizedOperator"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Burned.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Burned.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "data",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "operatorData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Burned",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "data",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operatorData",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_Burned"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Minted.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Minted.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "data",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "operatorData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Minted",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "data",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operatorData",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_Minted"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_MinterAdded.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_MinterAdded.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MinterAdded",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_MinterAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_MinterRemoved.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_MinterRemoved.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "MinterRemoved",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_MinterRemoved"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_OwnershipTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Paused.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_RevenueAddressSet.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_RevenueAddressSet.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "RevenueAddressSet",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_RevenueAddressSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_RevenueDistributed.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_RevenueDistributed.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "exchangeRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "remainder",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RevenueDistributed",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "exchangeRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "remainder",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_RevenueDistributed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_RevokedOperator.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_RevokedOperator.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "tokenHolder",
+                    "type": "address"
+                }
+            ],
+            "name": "RevokedOperator",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenHolder",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_RevokedOperator"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Sent.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Sent.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "data",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "operatorData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Sent",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "data",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operatorData",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_Sent"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Transfer.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_TransferDisabled.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_TransferDisabled.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                }
+            ],
+            "name": "TransferDisabled",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_TransferDisabled"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_TransferEnabled.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_TransferEnabled.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                }
+            ],
+            "name": "TransferEnabled",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_TransferEnabled"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/imbtc/IMBTC_event_Unpaused.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0x3212b29e33587a00fb1c83346f5dbfa69a458923",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "imbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "IMBTC_event_Unpaused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Approval.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x5228a22e72ccc52d415ecfd199f99d0665e7733b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ptokens",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "pBTC_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_AuthorizedOperator.json
+++ b/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_AuthorizedOperator.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "tokenHolder",
+                    "type": "address"
+                }
+            ],
+            "name": "AuthorizedOperator",
+            "type": "event"
+        },
+        "contract_address": "0x5228a22e72ccc52d415ecfd199f99d0665e7733b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ptokens",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenHolder",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "pBTC_event_AuthorizedOperator"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Burned.json
+++ b/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Burned.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "data",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "operatorData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Burned",
+            "type": "event"
+        },
+        "contract_address": "0x5228a22e72ccc52d415ecfd199f99d0665e7733b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ptokens",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "data",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operatorData",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "pBTC_event_Burned"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Minted.json
+++ b/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Minted.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "data",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "operatorData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Minted",
+            "type": "event"
+        },
+        "contract_address": "0x5228a22e72ccc52d415ecfd199f99d0665e7733b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ptokens",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "data",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operatorData",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "pBTC_event_Minted"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Redeem.json
+++ b/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Redeem.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "redeemer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "underlyingAssetRecipient",
+                    "type": "string"
+                }
+            ],
+            "name": "Redeem",
+            "type": "event"
+        },
+        "contract_address": "0x5228a22e72ccc52d415ecfd199f99d0665e7733b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ptokens",
+        "schema": [
+            {
+                "description": "",
+                "name": "redeemer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "underlyingAssetRecipient",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "pBTC_event_Redeem"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_RevokedOperator.json
+++ b/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_RevokedOperator.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "tokenHolder",
+                    "type": "address"
+                }
+            ],
+            "name": "RevokedOperator",
+            "type": "event"
+        },
+        "contract_address": "0x5228a22e72ccc52d415ecfd199f99d0665e7733b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ptokens",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenHolder",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "pBTC_event_RevokedOperator"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Sent.json
+++ b/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Sent.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "operator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "data",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "operatorData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Sent",
+            "type": "event"
+        },
+        "contract_address": "0x5228a22e72ccc52d415ecfd199f99d0665e7733b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ptokens",
+        "schema": [
+            {
+                "description": "",
+                "name": "operator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "data",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "operatorData",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "pBTC_event_Sent"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/ptokens/pBTC_event_Transfer.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x5228a22e72ccc52d415ecfd199f99d0665e7733b",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "ptokens",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "pBTC_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_call_burn.json
+++ b/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_call_burn.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_from",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "burn",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "_from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_burn"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_call_burn.json
+++ b/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_call_burn.json
@@ -25,7 +25,7 @@
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "renbtc",
         "schema": [
             {
                 "description": "",
@@ -39,6 +39,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_burn"
+        "table_name": "RenERC20LogicV1_call_burn"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_call_mint.json
+++ b/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_call_mint.json
@@ -25,7 +25,7 @@
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "renbtc",
         "schema": [
             {
                 "description": "",
@@ -39,6 +39,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_mint"
+        "table_name": "RenERC20LogicV1_call_mint"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_call_mint.json
+++ b/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_call_mint.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mint",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "_to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_mint"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "renbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "RenERC20LogicV1_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_event_LogRateChanged.json
+++ b/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_event_LogRateChanged.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "_rate",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogRateChanged",
+            "type": "event"
+        },
+        "contract_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "renbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "_rate",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "RenERC20LogicV1_event_LogRateChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "renbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "RenERC20LogicV1_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/renbtc/RenERC20LogicV1_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "renbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "RenERC20LogicV1_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Approval.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "sBTC_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Burned.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Burned.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burned",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "sBTC_event_Burned"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Issued.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Issued.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Issued",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "sBTC_event_Issued"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_OwnerChanged.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_OwnerChanged.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "oldOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerChanged",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "sBTC_event_OwnerChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_OwnerNominated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_OwnerNominated.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerNominated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "sBTC_event_OwnerNominated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_ProxyUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_ProxyUpdated.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "proxyAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "ProxyUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "proxyAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "sBTC_event_ProxyUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructBeneficiaryUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructBeneficiaryUpdated.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "newBeneficiary",
+                    "type": "address"
+                }
+            ],
+            "name": "SelfDestructBeneficiaryUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "newBeneficiary",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "sBTC_event_SelfDestructBeneficiaryUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructInitiated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructInitiated.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "selfDestructDelay",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SelfDestructInitiated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "selfDestructDelay",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "sBTC_event_SelfDestructInitiated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructTerminated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructTerminated.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "SelfDestructTerminated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [],
+        "table_description": "",
+        "table_name": "sBTC_event_SelfDestructTerminated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructed.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructed.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "beneficiary",
+                    "type": "address"
+                }
+            ],
+            "name": "SelfDestructed",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "beneficiary",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "sBTC_event_SelfDestructed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_TokenStateUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_TokenStateUpdated.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "newTokenState",
+                    "type": "address"
+                }
+            ],
+            "name": "TokenStateUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "newTokenState",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "sBTC_event_TokenStateUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Transfer.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "sBTC_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tbtc/TBTCToken_call_burn.json
+++ b/dags/resources/stages/parse/table_definitions/tbtc/TBTCToken_call_burn.json
@@ -1,0 +1,34 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "burn",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x1bbe271d15bb64df0bc6cd28df9ff322f2ebd847",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "tbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TBTCToken_call_burn"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tbtc/TBTCToken_call_burnFrom.json
+++ b/dags/resources/stages/parse/table_definitions/tbtc/TBTCToken_call_burnFrom.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "burnFrom",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x1bbe271d15bb64df0bc6cd28df9ff322f2ebd847",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "tbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "_account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TBTCToken_call_burnFrom"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tbtc/TBTCToken_call_mint.json
+++ b/dags/resources/stages/parse/table_definitions/tbtc/TBTCToken_call_mint.json
@@ -1,0 +1,50 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mint",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x1bbe271d15bb64df0bc6cd28df9ff322f2ebd847",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "tbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "_account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TBTCToken_call_mint"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tbtc/TBTCToken_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/tbtc/TBTCToken_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0x1bbe271d15bb64df0bc6cd28df9ff322f2ebd847",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "tbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TBTCToken_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tbtc/TBTCToken_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/tbtc/TBTCToken_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x1bbe271d15bb64df0bc6cd28df9ff322f2ebd847",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "tbtc",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TBTCToken_event_Transfer"
+    }
+}


### PR DESCRIPTION
Fixes #111 

- [x] renBTC: `0xeb4c2781e4eba804ce9a9803c67d0893436bb27d` (proxy for `0xe2d6ccac3ee3a21abf7bedbe2e107ffc0c037e80`)
- [x]  HBTC: `0x0316eb71485b0ab14103307bf65a021042c6d380`
- [x]  sBTC: `0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6` and `0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b`
- [x]  imBTC: `0x3212b29e33587a00fb1c83346f5dbfa69a458923`
- [x]  pBTC: `0x5228a22e72ccc52d415ecfd199f99d0665e7733b`
- [x]  tBTC: `0x1bbe271d15bb64df0bc6cd28df9ff322f2ebd847`

Used https://contract-parser.d5.ai