### PR TITLE
Replaced 'target' address with old sBTC contract to capture all events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Approval.json
@@ -22,7 +22,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Burned.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Burned.json
@@ -17,7 +17,7 @@
             "name": "Burned",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Issued.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Issued.json
@@ -17,7 +17,7 @@
             "name": "Issued",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_OwnerChanged.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_OwnerChanged.json
@@ -17,7 +17,7 @@
             "name": "OwnerChanged",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_OwnerNominated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_OwnerNominated.json
@@ -12,7 +12,7 @@
             "name": "OwnerNominated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_ProxyUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_ProxyUpdated.json
@@ -12,7 +12,7 @@
             "name": "ProxyUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructBeneficiaryUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructBeneficiaryUpdated.json
@@ -12,7 +12,7 @@
             "name": "SelfDestructBeneficiaryUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructInitiated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructInitiated.json
@@ -12,7 +12,7 @@
             "name": "SelfDestructInitiated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructTerminated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructTerminated.json
@@ -6,7 +6,7 @@
             "name": "SelfDestructTerminated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructed.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_SelfDestructed.json
@@ -12,7 +12,7 @@
             "name": "SelfDestructed",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_TokenStateUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_TokenStateUpdated.json
@@ -12,7 +12,7 @@
             "name": "TokenStateUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/sBTC_event_Transfer.json
@@ -22,7 +22,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT * FROM UNNEST(['0x17628a557d1fc88d1c35989dcbac3f3e275e2d2b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
+        "contract_address": "SELECT * FROM UNNEST(['0x9073ee83b6ce96c444547ddcaf777b9352163581', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6'])",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
sBTC used to be in this contract: `0x9073ee83b6ce96c444547ddcaf777b9352163581` so we have to include this to capture all sBTC events.

Previously I included the 'target' address of the new proxy for sBTC, but this didn't have any events (they all go to the proxy) so we can safely remove this and replace it with the above one.

We need to re-run jobs though to get the correct history.