### PR TITLE
Add SushiSwap pool events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Factory_event_PairCreated.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Factory_event_PairCreated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "token0",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "token1",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "pair",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_uint",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PairCreated",
+            "type": "event"
+        },
+        "contract_address": "0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "token0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pair",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_uint",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "UniswapV2Factory_event_PairCreated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Factory_event_PairCreated.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Factory_event_PairCreated.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "uniswap",
+        "dataset_name": "sushiswap",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "UniswapV2Pair_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Approval.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "uniswap",
+        "dataset_name": "sushiswap",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Burn.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Burn.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "UniswapV2Pair_event_Burn"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Burn.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Burn.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "uniswap",
+        "dataset_name": "sushiswap",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Mint.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "UniswapV2Pair_event_Mint"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Mint.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "uniswap",
+        "dataset_name": "sushiswap",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Swap.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Swap.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0In",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1In",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount0Out",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount1Out",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "Swap",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0In",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1In",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount0Out",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount1Out",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "UniswapV2Pair_event_Swap"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Swap.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Swap.json
@@ -48,7 +48,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "uniswap",
+        "dataset_name": "sushiswap",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Sync.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Sync.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve0",
+                    "type": "uint112"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint112",
+                    "name": "reserve1",
+                    "type": "uint112"
+                }
+            ],
+            "name": "Sync",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve0",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reserve1",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "UniswapV2Pair_event_Sync"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Sync.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Sync.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "uniswap",
+        "dataset_name": "sushiswap",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT pair FROM ref('UniswapV2Factory_event_PairCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "uniswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "UniswapV2Pair_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/sushiswap/UniswapV2Pair_event_Transfer.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "uniswap",
+        "dataset_name": "sushiswap",
         "schema": [
             {
                 "description": "",


### PR DESCRIPTION
Copied UniswapV2 and just replaced the Factory address.

The contracts are forked from UniswapV2 which is why the names are the same. I think that's OK given that they'll be on their own `ethereum_sushiswap` namespace.