### PR TITLE
Add transaction_index to parse_traces.sql and parse_logic.py

### DIFF
--- a/dags/ethereumetl_airflow/parse/parse_logic.py
+++ b/dags/ethereumetl_airflow/parse/parse_logic.py
@@ -360,6 +360,10 @@ def read_bigquery_schema_from_dict(schema, parser_type):
             description='Address of the contract that produced the log'))
     elif parser_type == 'trace':
         result.append(bigquery.SchemaField(
+            name='transaction_index',
+            field_type='INTEGER',
+            description='Integer of the transactions index position in the block'))
+        result.append(bigquery.SchemaField(
             name='trace_address',
             field_type='STRING',
             description='Comma separated list of trace address in call tree'))

--- a/dags/resources/stages/parse/sqls/parse_traces.sql
+++ b/dags/resources/stages/parse/sqls/parse_traces.sql
@@ -3,6 +3,7 @@ WITH parsed_traces AS
     traces.block_timestamp AS block_timestamp
     ,traces.block_number AS block_number
     ,traces.transaction_hash AS transaction_hash
+    ,traces.transaction_index AS transaction_index
     ,traces.trace_address AS trace_address
     ,traces.to_address AS to_address
     ,traces.status AS status
@@ -28,6 +29,7 @@ SELECT
      block_timestamp
      ,block_number
      ,transaction_hash
+     ,transaction_index
      ,trace_address
      ,to_address
      ,status

--- a/tests/resources/ethereumetl_airflow/test_parse/idex/Exchange_call_trade.json_True_1.sql
+++ b/tests/resources/ethereumetl_airflow/test_parse/idex/Exchange_call_trade.json_True_1.sql
@@ -3,6 +3,7 @@ WITH parsed_traces AS
     traces.block_timestamp AS block_timestamp
     ,traces.block_number AS block_number
     ,traces.transaction_hash AS transaction_hash
+    ,traces.transaction_index AS transaction_index
     ,traces.trace_address AS trace_address
     ,traces.to_address AS to_address
     ,traces.status AS status
@@ -22,6 +23,7 @@ SELECT
      block_timestamp
      ,block_number
      ,transaction_hash
+     ,transaction_index
      ,trace_address
      ,to_address
      ,status

--- a/tests/resources/ethereumetl_airflow/test_parse/idex/Exchange_call_trade.json_True_2.sql
+++ b/tests/resources/ethereumetl_airflow/test_parse/idex/Exchange_call_trade.json_True_2.sql
@@ -3,6 +3,7 @@ WITH parsed_traces AS
     traces.block_timestamp AS block_timestamp
     ,traces.block_number AS block_number
     ,traces.transaction_hash AS transaction_hash
+    ,traces.transaction_index AS transaction_index
     ,traces.trace_address AS trace_address
     ,traces.to_address AS to_address
     ,traces.status AS status
@@ -22,6 +23,7 @@ SELECT
      block_timestamp
      ,block_number
      ,transaction_hash
+     ,transaction_index
      ,trace_address
      ,to_address
      ,status


### PR DESCRIPTION
@medvedev1088 there are often multiple calls in the same block and the order the calls occurred in might be important. In our case at Balancer, we need to know what the last call in the block to some functions was. I'm a bit out of my depth here, but I tried to mimic what you did in 36663d9 and 33036c4. Let me know what you think. Thanks!