### PR TITLE
Added Swap Events for Mooniswap across all deployed Pools 

### DIFF
--- a/dags/resources/stages/parse/table_definitions/mooniswap/Mooniswap_v2_event_Swapped.json
+++ b/dags/resources/stages/parse/table_definitions/mooniswap/Mooniswap_v2_event_Swapped.json
@@ -1,0 +1,120 @@
+{
+  "parser": {
+    "abi": {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "srcToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "dstToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "result",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "srcAdditionBalance",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "dstRemovalBalance",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "referral",
+          "type": "address"
+        }
+      ],
+      "name": "Swapped",
+      "type": "event"
+    },
+    "contract_address": "SELECT mooniswap FROM ref('MooniswapFactory_event_Deployed')",
+    "field_mapping": {},
+    "type": "log"
+  },
+  "table": {
+    "dataset_name": "mooniswap",
+    "schema": [
+      {
+        "description": "",
+        "name": "sender",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "receiver",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "srcToken",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "dstToken",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "amount",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "result",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "srcAdditionBalance",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "dstRemovalBalance",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "name": "referral",
+        "type": "STRING"
+      }
+    ],
+    "table_description": "",
+    "table_name": "Mooniswap_v2_event_Swapped"
+  }
+}


### PR DESCRIPTION
- Added this based on looking at source code here: https://etherscan.io/address/0xa31bb36c5164b165f9c36955ea4ccbab42b3b28e#code

```
    event Swapped(
        address indexed sender,
        address indexed receiver,
        address indexed srcToken,
        address dstToken,
        uint256 amount,
        uint256 result,
        uint256 srcAdditionBalance,
        uint256 dstRemovalBalance,
        address referral
    );

```

- and ABI from here https://github.com/wellttllew/1inch-flow



Use:

```
     "contract_address": "SELECT mooniswap FROM ref('MooniswapFactory_event_Deployed')",
```
to work across all deployed pools 