### PR TITLE
Add totle contracts that have swap events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_Log.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_Log.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "a",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "name": "b",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "c",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "Log",
+            "type": "event"
+        },
+        "contract_address": "0x623520377f092c1c70bd57d17ae9ede6a288412c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "a",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "b",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "c",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v2_event_Log"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_LogSwap.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_LogSwap.json
@@ -1,0 +1,91 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "sourceAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "destinationAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "sourceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "destinationAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogSwap",
+            "type": "event"
+        },
+        "contract_address": "0x623520377f092c1c70bd57d17ae9ede6a288412c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destinationAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destinationAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v2_event_LogSwap"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_LogSwapCollection.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_LogSwapCollection.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "partnerContract",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "user",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSwapCollection",
+            "type": "event"
+        },
+        "contract_address": "0x623520377f092c1c70bd57d17ae9ede6a288412c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "partnerContract",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v2_event_LogSwapCollection"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_OwnershipRenounced.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_OwnershipRenounced.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipRenounced",
+            "type": "event"
+        },
+        "contract_address": "0x623520377f092c1c70bd57d17ae9ede6a288412c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v2_event_OwnershipRenounced"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_OwnershipTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x623520377f092c1c70bd57d17ae9ede6a288412c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v2_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_Paused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0x623520377f092c1c70bd57d17ae9ede6a288412c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [],
+        "table_description": "",
+        "table_name": "TotlePrimary_v2_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v2_event_Unpaused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0x623520377f092c1c70bd57d17ae9ede6a288412c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [],
+        "table_description": "",
+        "table_name": "TotlePrimary_v2_event_Unpaused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_Log.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_Log.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "a",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "name": "b",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "c",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "Log",
+            "type": "event"
+        },
+        "contract_address": "0xcd2053679de3bcf2b7e2c2efb6b499c57701222c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "a",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "b",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "c",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v3_event_Log"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_LogSwap.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_LogSwap.json
@@ -1,0 +1,91 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "sourceAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "destinationAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "sourceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "destinationAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogSwap",
+            "type": "event"
+        },
+        "contract_address": "0xcd2053679de3bcf2b7e2c2efb6b499c57701222c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destinationAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destinationAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v3_event_LogSwap"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_LogSwapCollection.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_LogSwapCollection.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "partnerContract",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "user",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSwapCollection",
+            "type": "event"
+        },
+        "contract_address": "0xcd2053679de3bcf2b7e2c2efb6b499c57701222c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "partnerContract",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v3_event_LogSwapCollection"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_OwnershipRenounced.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_OwnershipRenounced.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipRenounced",
+            "type": "event"
+        },
+        "contract_address": "0xcd2053679de3bcf2b7e2c2efb6b499c57701222c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v3_event_OwnershipRenounced"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_OwnershipTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0xcd2053679de3bcf2b7e2c2efb6b499c57701222c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v3_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_Paused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0xcd2053679de3bcf2b7e2c2efb6b499c57701222c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [],
+        "table_description": "",
+        "table_name": "TotlePrimary_v3_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v3_event_Unpaused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0xcd2053679de3bcf2b7e2c2efb6b499c57701222c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [],
+        "table_description": "",
+        "table_name": "TotlePrimary_v3_event_Unpaused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_Log.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_Log.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "a",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "name": "b",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "c",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "Log",
+            "type": "event"
+        },
+        "contract_address": "0x37629db35889e1e87dcee07b171efd565e571e05",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "a",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "b",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "c",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v4_event_Log"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_LogSwap.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_LogSwap.json
@@ -1,0 +1,91 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "sourceAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "destinationAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "sourceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "destinationAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogSwap",
+            "type": "event"
+        },
+        "contract_address": "0x37629db35889e1e87dcee07b171efd565e571e05",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destinationAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destinationAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v4_event_LogSwap"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_LogSwapCollection.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_LogSwapCollection.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "partnerContract",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "user",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSwapCollection",
+            "type": "event"
+        },
+        "contract_address": "0x37629db35889e1e87dcee07b171efd565e571e05",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "partnerContract",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v4_event_LogSwapCollection"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_OwnershipRenounced.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_OwnershipRenounced.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipRenounced",
+            "type": "event"
+        },
+        "contract_address": "0x37629db35889e1e87dcee07b171efd565e571e05",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v4_event_OwnershipRenounced"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_OwnershipTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x37629db35889e1e87dcee07b171efd565e571e05",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v4_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_Paused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0x37629db35889e1e87dcee07b171efd565e571e05",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [],
+        "table_description": "",
+        "table_name": "TotlePrimary_v4_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v4_event_Unpaused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0x37629db35889e1e87dcee07b171efd565e571e05",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [],
+        "table_description": "",
+        "table_name": "TotlePrimary_v4_event_Unpaused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_Log.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_Log.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "a",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "name": "b",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "c",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "Log",
+            "type": "event"
+        },
+        "contract_address": "0xc755af998e8c50d6df1779ce3d7e4084a17b4c56",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "a",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "b",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "c",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v5_event_Log"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_LogSwap.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_LogSwap.json
@@ -1,0 +1,91 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "sourceAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "destinationAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "sourceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "destinationAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogSwap",
+            "type": "event"
+        },
+        "contract_address": "0xc755af998e8c50d6df1779ce3d7e4084a17b4c56",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destinationAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destinationAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v5_event_LogSwap"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_LogSwapCollection.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_LogSwapCollection.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "partnerContract",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "user",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSwapCollection",
+            "type": "event"
+        },
+        "contract_address": "0xc755af998e8c50d6df1779ce3d7e4084a17b4c56",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "partnerContract",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v5_event_LogSwapCollection"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_OwnershipRenounced.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_OwnershipRenounced.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipRenounced",
+            "type": "event"
+        },
+        "contract_address": "0xc755af998e8c50d6df1779ce3d7e4084a17b4c56",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v5_event_OwnershipRenounced"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_OwnershipTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0xc755af998e8c50d6df1779ce3d7e4084a17b4c56",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v5_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_Paused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0xc755af998e8c50d6df1779ce3d7e4084a17b4c56",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [],
+        "table_description": "",
+        "table_name": "TotlePrimary_v5_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v5_event_Unpaused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0xc755af998e8c50d6df1779ce3d7e4084a17b4c56",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [],
+        "table_description": "",
+        "table_name": "TotlePrimary_v5_event_Unpaused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_Log.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_Log.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "a",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "name": "b",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "c",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "Log",
+            "type": "event"
+        },
+        "contract_address": "0x3b21d6d25e7f036c8277efe9a7ebf17ca12fe4f6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "a",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "b",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "c",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v6_event_Log"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_LogSwap.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_LogSwap.json
@@ -1,0 +1,91 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "sourceAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "destinationAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "sourceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "destinationAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LogSwap",
+            "type": "event"
+        },
+        "contract_address": "0x3b21d6d25e7f036c8277efe9a7ebf17ca12fe4f6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destinationAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destinationAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v6_event_LogSwap"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_LogSwapCollection.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_LogSwapCollection.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "partnerContract",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "user",
+                    "type": "address"
+                }
+            ],
+            "name": "LogSwapCollection",
+            "type": "event"
+        },
+        "contract_address": "0x3b21d6d25e7f036c8277efe9a7ebf17ca12fe4f6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "partnerContract",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v6_event_LogSwapCollection"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_OwnershipRenounced.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_OwnershipRenounced.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipRenounced",
+            "type": "event"
+        },
+        "contract_address": "0x3b21d6d25e7f036c8277efe9a7ebf17ca12fe4f6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v6_event_OwnershipRenounced"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_OwnershipTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x3b21d6d25e7f036c8277efe9a7ebf17ca12fe4f6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TotlePrimary_v6_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_Paused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0x3b21d6d25e7f036c8277efe9a7ebf17ca12fe4f6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [],
+        "table_description": "",
+        "table_name": "TotlePrimary_v6_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/totle/TotlePrimary_v6_event_Unpaused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0x3b21d6d25e7f036c8277efe9a7ebf17ca12fe4f6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "totle",
+        "schema": [],
+        "table_description": "",
+        "table_name": "TotlePrimary_v6_event_Unpaused"
+    }
+}


### PR DESCRIPTION
https://github.com/TotlePlatform/contracts/commits/master/README.md

Used the above to add the different contracts. 

The first contract deployed is missing a swap event. 

The second contract deployed does not have code verified on etherscan. 

So the contracts listed are from v2 onwards. Specifically from this PR onwards. 

https://github.com/TotlePlatform/contracts/commit/f8bb236dbe6be1b8493bed131396487e45b99e5c#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5