### PR TITLE
add older paraswap contracts

### DIFF
--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_OwnershipTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x6b158039b9678b7452f311deb12dd08c579dad26",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v1_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_Paused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0x6b158039b9678b7452f311deb12dd08c579dad26",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v1_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_Payed.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_Payed.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "srcToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "destToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "srcAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "receivedAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Payed",
+            "type": "event"
+        },
+        "contract_address": "0x6b158039b9678b7452f311deb12dd08c579dad26",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "receivedAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v1_event_Payed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_Swapped.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_Swapped.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "srcToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "destToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "srcAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "receivedAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Swapped",
+            "type": "event"
+        },
+        "contract_address": "0x6b158039b9678b7452f311deb12dd08c579dad26",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "receivedAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v1_event_Swapped"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_Unpaused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0x6b158039b9678b7452f311deb12dd08c579dad26",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v1_event_Unpaused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_WhitelistAdded.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_WhitelistAdded.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "WhitelistAdded",
+            "type": "event"
+        },
+        "contract_address": "0x6b158039b9678b7452f311deb12dd08c579dad26",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v1_event_WhitelistAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_WhitelistRemoved.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v1_event_WhitelistRemoved.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "WhitelistRemoved",
+            "type": "event"
+        },
+        "contract_address": "0x6b158039b9678b7452f311deb12dd08c579dad26",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v1_event_WhitelistRemoved"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_OwnershipTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x72338b82800400f5488eca2b5a37270ba3b7a111",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v2_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_Paused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0x72338b82800400f5488eca2b5a37270ba3b7a111",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v2_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_Payed.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_Payed.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "srcToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "destToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "srcAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "receivedAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Payed",
+            "type": "event"
+        },
+        "contract_address": "0x72338b82800400f5488eca2b5a37270ba3b7a111",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "receivedAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v2_event_Payed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_Swapped.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_Swapped.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "srcToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "destToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "srcAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "receivedAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Swapped",
+            "type": "event"
+        },
+        "contract_address": "0x72338b82800400f5488eca2b5a37270ba3b7a111",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "receivedAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v2_event_Swapped"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_Unpaused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0x72338b82800400f5488eca2b5a37270ba3b7a111",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v2_event_Unpaused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_WhitelistAdded.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_WhitelistAdded.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "WhitelistAdded",
+            "type": "event"
+        },
+        "contract_address": "0x72338b82800400f5488eca2b5a37270ba3b7a111",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v2_event_WhitelistAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_WhitelistRemoved.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v2_event_WhitelistRemoved.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "WhitelistRemoved",
+            "type": "event"
+        },
+        "contract_address": "0x72338b82800400f5488eca2b5a37270ba3b7a111",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v2_event_WhitelistRemoved"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_OwnershipTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0xf92c1ad75005e6436b4ee84e88cb23ed8a290988",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v3_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_Paused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0xf92c1ad75005e6436b4ee84e88cb23ed8a290988",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v3_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_Payed.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_Payed.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "srcToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "destToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "srcAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "receivedAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "referrer",
+                    "type": "string"
+                }
+            ],
+            "name": "Payed",
+            "type": "event"
+        },
+        "contract_address": "0xf92c1ad75005e6436b4ee84e88cb23ed8a290988",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "receivedAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "referrer",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v3_event_Payed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_Swapped.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_Swapped.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "srcToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "destToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "srcAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "receivedAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "referrer",
+                    "type": "string"
+                }
+            ],
+            "name": "Swapped",
+            "type": "event"
+        },
+        "contract_address": "0xf92c1ad75005e6436b4ee84e88cb23ed8a290988",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "destToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "srcAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "receivedAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "referrer",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v3_event_Swapped"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_Unpaused.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0xf92c1ad75005e6436b4ee84e88cb23ed8a290988",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v3_event_Unpaused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_WhitelistAdded.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_WhitelistAdded.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "WhitelistAdded",
+            "type": "event"
+        },
+        "contract_address": "0xf92c1ad75005e6436b4ee84e88cb23ed8a290988",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v3_event_WhitelistAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_WhitelistRemoved.json
+++ b/dags/resources/stages/parse/table_definitions/paraswap/AugustusSwapperOld_v3_event_WhitelistRemoved.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "WhitelistRemoved",
+            "type": "event"
+        },
+        "contract_address": "0xf92c1ad75005e6436b4ee84e88cb23ed8a290988",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "paraswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AugustusSwapperOld_v3_event_WhitelistRemoved"
+    }
+}


### PR DESCRIPTION
Added the legacy contracts for paraswap labelled by etherscan over here:

https://etherscan.io/accounts/label/paraswap?subcatid=2&size=7&start=0&col=1&order=asc