### PR TITLE
Add Lido Voting events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/lido/Voting_event_CastVote.json
+++ b/dags/resources/stages/parse/table_definitions/lido/Voting_event_CastVote.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "voteId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "name": "voter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "supports",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "name": "stake",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CastVote",
+            "type": "event"
+        },
+        "contract_address": "0x2e59a20f205bb85a89c53f1936454680651e618e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "lido",
+        "schema": [
+            {
+                "description": "",
+                "name": "voteId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "voter",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "supports",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stake",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Voting_event_CastVote"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/lido/Voting_event_ChangeMinQuorum.json
+++ b/dags/resources/stages/parse/table_definitions/lido/Voting_event_ChangeMinQuorum.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "minAcceptQuorumPct",
+                    "type": "uint64"
+                }
+            ],
+            "name": "ChangeMinQuorum",
+            "type": "event"
+        },
+        "contract_address": "0x2e59a20f205bb85a89c53f1936454680651e618e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "lido",
+        "schema": [
+            {
+                "description": "",
+                "name": "minAcceptQuorumPct",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Voting_event_ChangeMinQuorum"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/lido/Voting_event_ChangeSupportRequired.json
+++ b/dags/resources/stages/parse/table_definitions/lido/Voting_event_ChangeSupportRequired.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "supportRequiredPct",
+                    "type": "uint64"
+                }
+            ],
+            "name": "ChangeSupportRequired",
+            "type": "event"
+        },
+        "contract_address": "0x2e59a20f205bb85a89c53f1936454680651e618e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "lido",
+        "schema": [
+            {
+                "description": "",
+                "name": "supportRequiredPct",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Voting_event_ChangeSupportRequired"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/lido/Voting_event_ExecuteVote.json
+++ b/dags/resources/stages/parse/table_definitions/lido/Voting_event_ExecuteVote.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "voteId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ExecuteVote",
+            "type": "event"
+        },
+        "contract_address": "0x2e59a20f205bb85a89c53f1936454680651e618e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "lido",
+        "schema": [
+            {
+                "description": "",
+                "name": "voteId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Voting_event_ExecuteVote"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/lido/Voting_event_RecoverToVault.json
+++ b/dags/resources/stages/parse/table_definitions/lido/Voting_event_RecoverToVault.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "vault",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RecoverToVault",
+            "type": "event"
+        },
+        "contract_address": "0x2e59a20f205bb85a89c53f1936454680651e618e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "lido",
+        "schema": [
+            {
+                "description": "",
+                "name": "vault",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Voting_event_RecoverToVault"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/lido/Voting_event_ScriptResult.json
+++ b/dags/resources/stages/parse/table_definitions/lido/Voting_event_ScriptResult.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "executor",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "script",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "input",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "returnData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "ScriptResult",
+            "type": "event"
+        },
+        "contract_address": "0x2e59a20f205bb85a89c53f1936454680651e618e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "lido",
+        "schema": [
+            {
+                "description": "",
+                "name": "executor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "script",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "input",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "returnData",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Voting_event_ScriptResult"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/lido/Voting_event_StartVote.json
+++ b/dags/resources/stages/parse/table_definitions/lido/Voting_event_StartVote.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "voteId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "name": "creator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "metadata",
+                    "type": "string"
+                }
+            ],
+            "name": "StartVote",
+            "type": "event"
+        },
+        "contract_address": "0x2e59a20f205bb85a89c53f1936454680651e618e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "lido",
+        "schema": [
+            {
+                "description": "",
+                "name": "voteId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "creator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "metadata",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Voting_event_StartVote"
+    }
+}


### PR DESCRIPTION
Used https://contract-parser.d5.ai and then replaced implementation address with proxy address as follows:
```
sed -i '.bak' 's/0xb935c3d80229d5d92f3761b17cd81dc2610e3a45/0x2e59a20f205bb85a89c53f1936454680651e618e/g' Voting*
```
