### PR TITLE
Testing cleaning up bancor

### DIFF
--- a/dags/resources/stages/parse/table_definitions/bancor_network/BancorConverterFactory_event_NewConverter.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/BancorConverterFactory_event_NewConverter.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "_converter",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "_owner",
+                    "type": "address"
+                }
+            ],
+            "name": "NewConverter",
+            "type": "event"
+        },
+        "contract_address": "SELECT _contractAddress FROM ref('ContractRegistry_event_AddressUpdate') WHERE _contractName = '0x42616e636f72436f6e766572746572466163746f727900000000000000000000' UNION ALL SELECT '0x9afb9d7ed0f6c054ec76ea61d5cabc384d4dcb25' AS _contractAddress ",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_converter",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_owner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorConverterFactory_event_NewConverter"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/BancorConverterFactory_v2_event_NewConverter.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/BancorConverterFactory_v2_event_NewConverter.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint16",
+                    "name": "_type",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IConverter",
+                    "name": "_converter",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_owner",
+                    "type": "address"
+                }
+            ],
+            "name": "NewConverter",
+            "type": "event"
+        },
+        "contract_address": "SELECT _contractAddress FROM ref('ContractRegistry_event_AddressUpdate') WHERE _contractName = '0x42616e636f72436f6e766572746572466163746f727900000000000000000000' ",       
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_type",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_converter",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_owner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorConverterFactory_v2_event_NewConverter"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/ContractRegistry_event_AddressUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/ContractRegistry_event_AddressUpdate.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "_contractName",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "_contractAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "AddressUpdate",
+            "type": "event"
+        },
+        "contract_address": "0x52ae12abe5d8bd778bd5397f99ca900624cfadd4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_contractName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_contractAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ContractRegistry_event_AddressUpdate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/ContractRegistry_event_OwnerUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/ContractRegistry_event_OwnerUpdate.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "_prevOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "_newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerUpdate",
+            "type": "event"
+        },
+        "contract_address": "0x52ae12abe5d8bd778bd5397f99ca900624cfadd4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_prevOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ContractRegistry_event_OwnerUpdate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_Activation.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_Activation.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "_anchor",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "_activated",
+                    "type": "bool"
+                }
+            ],
+            "name": "Activation",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_anchor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_activated",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_event_Activation"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_Conversion.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_Conversion.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "_fromToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "_toToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "_trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "_amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "_return",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "_conversionFee",
+                    "type": "int256"
+                }
+            ],
+            "name": "Conversion",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_fromToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_toToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_trader",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_return",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_conversionFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_event_Conversion"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_ConversionFeeUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_ConversionFeeUpdate.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "_prevFee",
+                    "type": "uint32"
+                },
+                {
+                    "indexed": false,
+                    "name": "_newFee",
+                    "type": "uint32"
+                }
+            ],
+            "name": "ConversionFeeUpdate",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_prevFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_event_ConversionFeeUpdate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_LiquidityAdded.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_LiquidityAdded.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "_provider",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "_reserveToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "_amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "_newBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "_newSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidityAdded",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_provider",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_reserveToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_event_LiquidityAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_LiquidityRemoved.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_LiquidityRemoved.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "_provider",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "_reserveToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "_amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "_newBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "_newSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidityRemoved",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_provider",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_reserveToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_event_LiquidityRemoved"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_OwnerUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_OwnerUpdate.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "_prevOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "_newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerUpdate",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_prevOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_event_OwnerUpdate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_PriceDataUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_PriceDataUpdate.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "_connectorToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "_tokenSupply",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "_connectorBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "_connectorWeight",
+                    "type": "uint32"
+                }
+            ],
+            "name": "PriceDataUpdate",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_connectorToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_tokenSupply",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_connectorBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_connectorWeight",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_event_PriceDataUpdate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_TokenRateUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_event_TokenRateUpdate.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "_token1",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "_token2",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "_rateN",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "_rateD",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TokenRateUpdate",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_token1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_token2",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_rateN",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_rateD",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_event_TokenRateUpdate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_Activation.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_Activation.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint16",
+                    "name": "_type",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IConverterAnchor",
+                    "name": "_anchor",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bool",
+                    "name": "_activated",
+                    "type": "bool"
+                }
+            ],
+            "name": "Activation",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_v2_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_type",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_anchor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_activated",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_v2_event_Activation"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_Conversion.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_Conversion.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IERC20Token",
+                    "name": "_fromToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IERC20Token",
+                    "name": "_toToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_return",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int256",
+                    "name": "_conversionFee",
+                    "type": "int256"
+                }
+            ],
+            "name": "Conversion",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_v2_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_fromToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_toToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_trader",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_return",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_conversionFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_v2_event_Conversion"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_ConversionFeeUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_ConversionFeeUpdate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "_prevFee",
+                    "type": "uint32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "_newFee",
+                    "type": "uint32"
+                }
+            ],
+            "name": "ConversionFeeUpdate",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_v2_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_prevFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_v2_event_ConversionFeeUpdate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_LiquidityAdded.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_LiquidityAdded.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_provider",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IERC20Token",
+                    "name": "_reserveToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_newBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_newSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidityAdded",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_v2_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_provider",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_reserveToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_v2_event_LiquidityAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_LiquidityRemoved.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_LiquidityRemoved.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_provider",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IERC20Token",
+                    "name": "_reserveToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_newBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_newSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidityRemoved",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_v2_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_provider",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_reserveToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_v2_event_LiquidityRemoved"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_OwnerUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_OwnerUpdate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_prevOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerUpdate",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_v2_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_prevOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_v2_event_OwnerUpdate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_TokenRateUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_TokenRateUpdate.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IERC20Token",
+                    "name": "_token1",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IERC20Token",
+                    "name": "_token2",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_rateN",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_rateD",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TokenRateUpdate",
+            "type": "event"
+        },
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_v2_event_NewConverter')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor_network",
+        "schema": [
+            {
+                "description": "",
+                "name": "_token1",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_token2",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_rateN",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_rateD",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Converter_v2_event_TokenRateUpdate"
+    }
+}


### PR DESCRIPTION
Created a new data set called `bancor_network` to try test improved coverage for two different versions of newConverter events.

In my hypothesis this should improve coverage, compared to the existing `bancor` dataset. This also cleans up the names of the contracts 