### PR TITLE
Add the same contracts for v2_event_Conversion , incase some are v2

### DIFF
--- a/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_Conversion.json
+++ b/dags/resources/stages/parse/table_definitions/bancor_network/Converter_v2_event_Conversion.json
@@ -43,7 +43,7 @@
             "name": "Conversion",
             "type": "event"
         },
-        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_v2_event_NewConverter')",
+        "contract_address": "SELECT _converter FROM ref('BancorConverterFactory_v2_event_NewConverter')  UNION ALL SELECT _contractAddress AS _converter FROM ref('ContractRegistry_event_AddressUpdate') WHERE _contractName = '0x424e54436f6e7665727465720000000000000000000000000000000000000000' ",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
Some of the contracts exist here ``` SELECT _contractAddress AS _converter FROM ref('ContractRegistry_event_AddressUpdate') WHERE _contractName = '0x424e54436f6e7665727465720000000000000000000000000000000000000000'  ``` are v2, so added in here for complete coverage 