### PR TITLE
Missing address alias in token_amendaments

### DIFF
--- a/dags/resources/stages/enrich/sqls/amended_tokens.sql
+++ b/dags/resources/stages/enrich/sqls/amended_tokens.sql
@@ -19,7 +19,7 @@ deduplicated_token_amendments AS (
     GROUP BY address
 )
 SELECT 
-    LOWER(address),
+    LOWER(address) as address,
     COALESCE(am.symbol, tokens.symbol) AS symbol,
     COALESCE(am.name, tokens.name) AS name,
     COALESCE(am.decimals, tokens.decimals) AS decimals,

--- a/dags/resources/stages/enrich/sqls/amended_tokens.sql
+++ b/dags/resources/stages/enrich/sqls/amended_tokens.sql
@@ -19,7 +19,7 @@ deduplicated_token_amendments AS (
     GROUP BY address
 )
 SELECT 
-    LOWER(address) as address,
+    LOWER(address) AS address,
     COALESCE(am.symbol, tokens.symbol) AS symbol,
     COALESCE(am.name, tokens.name) AS name,
     COALESCE(am.decimals, tokens.decimals) AS decimals,


### PR DESCRIPTION
Hi, 

First, I am sorry about the typo introduce by me in the PR #216 
I saw you added a validation, but seems it is missing the address alias in the column.
This has caused that the `address` column currently is `f0_`

![image](https://user-images.githubusercontent.com/7301545/110518539-e36f8e00-8114-11eb-9a24-0e0ca1f09abf.png)
