### PR TITLE
Add 0x v4 events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_LimitOrderFilled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_LimitOrderFilled.json
@@ -1,0 +1,142 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "feeRecipient",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "makerToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "takerToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "takerTokenFilledAmount",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "makerTokenFilledAmount",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "takerTokenFeeFilledAmount",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "protocolFeePaid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "pool",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "LimitOrderFilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v4_0_event_LimitOrderFilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "feeRecipient",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "makerToken",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerToken",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerTokenFilledAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "makerTokenFilledAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerTokenFeeFilledAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "protocolFeePaid",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "pool",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_RfqOrderFilled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_RfqOrderFilled.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "makerToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "takerToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "takerTokenFilledAmount",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "makerTokenFilledAmount",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "pool",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "RfqOrderFilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v4_0_event_RfqOrderFilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "makerToken",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerToken",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerTokenFilledAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "makerTokenFilledAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "pool",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- Manually created these files, since ExchangeProxy is a proxy contract, and the following instructions did not work: https://medium.com/@ASvanevik/how-to-add-proxy-ethereum-addresses-to-bigquery-d842ed001449

- Looked at zeroex github: https://github.com/0xProject/protocol/blob/e8ae64673f55e4dfd93eae12f67f36b7b267fe0e/docs/basics/events.rst#limitorderfilled and manually built these files.
- Currently address is set to the ExchangeProxy 