### PR TITLE
Rename tables and files

### DIFF
--- a/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_batchSwapExactIn.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_batchSwapExactIn.json
@@ -36,9 +36,9 @@
                             "type": "uint256"
                         }
                     ],
-                    "internalType": "struct ExchangeProxy.Swap[][]",
-                    "name": "swapSequences",
-                    "type": "tuple[][]"
+                    "internalType": "struct ExchangeProxy.Swap[]",
+                    "name": "swaps",
+                    "type": "tuple[]"
                 },
                 {
                     "internalType": "contract TokenInterface",
@@ -52,15 +52,20 @@
                 },
                 {
                     "internalType": "uint256",
-                    "name": "maxTotalAmountIn",
+                    "name": "totalAmountIn",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "minTotalAmountOut",
                     "type": "uint256"
                 }
             ],
-            "name": "multihopBatchSwapExactOut",
+            "name": "batchSwapExactIn",
             "outputs": [
                 {
                     "internalType": "uint256",
-                    "name": "totalAmountIn",
+                    "name": "totalAmountOut",
                     "type": "uint256"
                 }
             ],
@@ -77,7 +82,7 @@
         "schema": [
             {
                 "description": "",
-                "name": "swapSequences",
+                "name": "swaps",
                 "type": "STRING"
             },
             {
@@ -92,11 +97,16 @@
             },
             {
                 "description": "",
-                "name": "maxTotalAmountIn",
+                "name": "totalAmountIn",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "minTotalAmountOut",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "ExchangeProxy2_event_multihopBatchSwapExactOut"
+        "table_name": "ExchangeProxy2_call_batchSwapExactIn"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_batchSwapExactOut.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_batchSwapExactOut.json
@@ -52,20 +52,15 @@
                 },
                 {
                     "internalType": "uint256",
-                    "name": "totalAmountIn",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "minTotalAmountOut",
+                    "name": "maxTotalAmountIn",
                     "type": "uint256"
                 }
             ],
-            "name": "batchSwapExactIn",
+            "name": "batchSwapExactOut",
             "outputs": [
                 {
                     "internalType": "uint256",
-                    "name": "totalAmountOut",
+                    "name": "totalAmountIn",
                     "type": "uint256"
                 }
             ],
@@ -97,16 +92,11 @@
             },
             {
                 "description": "",
-                "name": "totalAmountIn",
-                "type": "STRING"
-            },
-            {
-                "description": "",
-                "name": "minTotalAmountOut",
+                "name": "maxTotalAmountIn",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "ExchangeProxy2_event_batchSwapExactIn"
+        "table_name": "ExchangeProxy2_call_batchSwapExactOut"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_multihopBatchSwapExactIn.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_multihopBatchSwapExactIn.json
@@ -36,9 +36,9 @@
                             "type": "uint256"
                         }
                     ],
-                    "internalType": "struct ExchangeProxy.Swap[]",
-                    "name": "swaps",
-                    "type": "tuple[]"
+                    "internalType": "struct ExchangeProxy.Swap[][]",
+                    "name": "swapSequences",
+                    "type": "tuple[][]"
                 },
                 {
                     "internalType": "contract TokenInterface",
@@ -52,15 +52,20 @@
                 },
                 {
                     "internalType": "uint256",
-                    "name": "maxTotalAmountIn",
+                    "name": "totalAmountIn",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "minTotalAmountOut",
                     "type": "uint256"
                 }
             ],
-            "name": "batchSwapExactOut",
+            "name": "multihopBatchSwapExactIn",
             "outputs": [
                 {
                     "internalType": "uint256",
-                    "name": "totalAmountIn",
+                    "name": "totalAmountOut",
                     "type": "uint256"
                 }
             ],
@@ -77,7 +82,7 @@
         "schema": [
             {
                 "description": "",
-                "name": "swaps",
+                "name": "swapSequences",
                 "type": "STRING"
             },
             {
@@ -92,11 +97,16 @@
             },
             {
                 "description": "",
-                "name": "maxTotalAmountIn",
+                "name": "totalAmountIn",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "minTotalAmountOut",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "ExchangeProxy2_event_batchSwapExactOut"
+        "table_name": "ExchangeProxy2_call_multihopBatchSwapExactIn"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_multihopBatchSwapExactOut.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_multihopBatchSwapExactOut.json
@@ -52,20 +52,15 @@
                 },
                 {
                     "internalType": "uint256",
-                    "name": "totalAmountIn",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "minTotalAmountOut",
+                    "name": "maxTotalAmountIn",
                     "type": "uint256"
                 }
             ],
-            "name": "multihopBatchSwapExactIn",
+            "name": "multihopBatchSwapExactOut",
             "outputs": [
                 {
                     "internalType": "uint256",
-                    "name": "totalAmountOut",
+                    "name": "totalAmountIn",
                     "type": "uint256"
                 }
             ],
@@ -97,16 +92,11 @@
             },
             {
                 "description": "",
-                "name": "totalAmountIn",
-                "type": "STRING"
-            },
-            {
-                "description": "",
-                "name": "minTotalAmountOut",
+                "name": "maxTotalAmountIn",
                 "type": "STRING"
             }
         ],
         "table_description": "",
-        "table_name": "ExchangeProxy2_event_multihopBatchSwapExactIn"
+        "table_name": "ExchangeProxy2_call_multihopBatchSwapExactOut"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_smartSwapExactIn.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_smartSwapExactIn.json
@@ -15,12 +15,12 @@
                 },
                 {
                     "internalType": "uint256",
-                    "name": "totalAmountOut",
+                    "name": "totalAmountIn",
                     "type": "uint256"
                 },
                 {
                     "internalType": "uint256",
-                    "name": "maxTotalAmountIn",
+                    "name": "minTotalAmountOut",
                     "type": "uint256"
                 },
                 {
@@ -29,11 +29,11 @@
                     "type": "uint256"
                 }
             ],
-            "name": "smartSwapExactOut",
+            "name": "smartSwapExactIn",
             "outputs": [
                 {
                     "internalType": "uint256",
-                    "name": "totalAmountIn",
+                    "name": "totalAmountOut",
                     "type": "uint256"
                 }
             ],
@@ -60,12 +60,12 @@
             },
             {
                 "description": "",
-                "name": "totalAmountOut",
+                "name": "totalAmountIn",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "maxTotalAmountIn",
+                "name": "minTotalAmountOut",
                 "type": "STRING"
             },
             {
@@ -75,6 +75,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "ExchangeProxy2_event_smartSwapExactOut"
+        "table_name": "ExchangeProxy2_call_smartSwapExactIn"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_smartSwapExactOut.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/ExchangeProxy2_call_smartSwapExactOut.json
@@ -15,12 +15,12 @@
                 },
                 {
                     "internalType": "uint256",
-                    "name": "totalAmountIn",
+                    "name": "totalAmountOut",
                     "type": "uint256"
                 },
                 {
                     "internalType": "uint256",
-                    "name": "minTotalAmountOut",
+                    "name": "maxTotalAmountIn",
                     "type": "uint256"
                 },
                 {
@@ -29,11 +29,11 @@
                     "type": "uint256"
                 }
             ],
-            "name": "smartSwapExactIn",
+            "name": "smartSwapExactOut",
             "outputs": [
                 {
                     "internalType": "uint256",
-                    "name": "totalAmountOut",
+                    "name": "totalAmountIn",
                     "type": "uint256"
                 }
             ],
@@ -60,12 +60,12 @@
             },
             {
                 "description": "",
-                "name": "totalAmountIn",
+                "name": "totalAmountOut",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "minTotalAmountOut",
+                "name": "maxTotalAmountIn",
                 "type": "STRING"
             },
             {
@@ -75,6 +75,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "ExchangeProxy2_event_smartSwapExactIn"
+        "table_name": "ExchangeProxy2_call_smartSwapExactOut"
     }
 }


### PR DESCRIPTION
@medvedev1088  Sorry about the new PR, but I didn't realize before that the table definitions downloaded from contract parser had "event" instead of "call" in the table name.