### PR TITLE
Update Chainlink Events to latest aggregator contracts

### DIFF
--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_AnswerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_AnswerUpdated.json
@@ -22,7 +22,7 @@
             "name": "AnswerUpdated",
             "type": "event"
         },
-        "contract_address": "0x05cf62c4ba0ccea3da680f9a8744ac51116d6231",
+        "contract_address": "0x7f7b323291c052de18926396176d384c4a8e19e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_ChainlinkFulfilled.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_ChainlinkFulfilled.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkFulfilled",
             "type": "event"
         },
-        "contract_address": "0x05cf62c4ba0ccea3da680f9a8744ac51116d6231",
+        "contract_address": "0x7f7b323291c052de18926396176d384c4a8e19e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_ChainlinkRequested.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_ChainlinkRequested.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkRequested",
             "type": "event"
         },
-        "contract_address": "0x05cf62c4ba0ccea3da680f9a8744ac51116d6231",
+        "contract_address": "0x7f7b323291c052de18926396176d384c4a8e19e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_NewRound.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_NewRound.json
@@ -17,7 +17,7 @@
             "name": "NewRound",
             "type": "event"
         },
-        "contract_address": "0x05cf62c4ba0ccea3da680f9a8744ac51116d6231",
+        "contract_address": "0x7f7b323291c052de18926396176d384c4a8e19e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_OwnershipTransferred.json
@@ -17,7 +17,7 @@
             "name": "OwnershipTransferred",
             "type": "event"
         },
-        "contract_address": "0x05cf62c4ba0ccea3da680f9a8744ac51116d6231",
+        "contract_address": "0x7f7b323291c052de18926396176d384c4a8e19e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_ResponseReceived.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_AUD_USD_event_ResponseReceived.json
@@ -22,7 +22,7 @@
             "name": "ResponseReceived",
             "type": "event"
         },
-        "contract_address": "0x05cf62c4ba0ccea3da680f9a8744ac51116d6231",
+        "contract_address": "0x7f7b323291c052de18926396176d384c4a8e19e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_AnswerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_AnswerUpdated.json
@@ -22,7 +22,7 @@
             "name": "AnswerUpdated",
             "type": "event"
         },
-        "contract_address": "0xf5fff180082d6017036b771ba883025c654bc935",
+        "contract_address": "0xae74faa92cb67a95ebcab07358bc222e33a34da7",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_ChainlinkFulfilled.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_ChainlinkFulfilled.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkFulfilled",
             "type": "event"
         },
-        "contract_address": "0xf5fff180082d6017036b771ba883025c654bc935",
+        "contract_address": "0xae74faa92cb67a95ebcab07358bc222e33a34da7",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_ChainlinkRequested.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_ChainlinkRequested.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkRequested",
             "type": "event"
         },
-        "contract_address": "0xf5fff180082d6017036b771ba883025c654bc935",
+        "contract_address": "0xae74faa92cb67a95ebcab07358bc222e33a34da7",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_NewRound.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_NewRound.json
@@ -17,7 +17,7 @@
             "name": "NewRound",
             "type": "event"
         },
-        "contract_address": "0xf5fff180082d6017036b771ba883025c654bc935",
+        "contract_address": "0xae74faa92cb67a95ebcab07358bc222e33a34da7",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_OwnershipTransferred.json
@@ -17,7 +17,7 @@
             "name": "OwnershipTransferred",
             "type": "event"
         },
-        "contract_address": "0xf5fff180082d6017036b771ba883025c654bc935",
+        "contract_address": "0xae74faa92cb67a95ebcab07358bc222e33a34da7",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_ResponseReceived.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_BTC_USD_event_ResponseReceived.json
@@ -22,7 +22,7 @@
             "name": "ResponseReceived",
             "type": "event"
         },
-        "contract_address": "0xf5fff180082d6017036b771ba883025c654bc935",
+        "contract_address": "0xae74faa92cb67a95ebcab07358bc222e33a34da7",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_AnswerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_AnswerUpdated.json
@@ -22,7 +22,7 @@
             "name": "AnswerUpdated",
             "type": "event"
         },
-        "contract_address": "0x02d5c618dbc591544b19d0bf13543c0728a3c4ec",
+        "contract_address": "0x7c8719f3683585a242a67c73f6f3c98362004da4",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_ChainlinkFulfilled.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_ChainlinkFulfilled.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkFulfilled",
             "type": "event"
         },
-        "contract_address": "0x02d5c618dbc591544b19d0bf13543c0728a3c4ec",
+        "contract_address": "0x7c8719f3683585a242a67c73f6f3c98362004da4",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_ChainlinkRequested.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_ChainlinkRequested.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkRequested",
             "type": "event"
         },
-        "contract_address": "0x02d5c618dbc591544b19d0bf13543c0728a3c4ec",
+        "contract_address": "0x7c8719f3683585a242a67c73f6f3c98362004da4",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_NewRound.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_NewRound.json
@@ -17,7 +17,7 @@
             "name": "NewRound",
             "type": "event"
         },
-        "contract_address": "0x02d5c618dbc591544b19d0bf13543c0728a3c4ec",
+        "contract_address": "0x7c8719f3683585a242a67c73f6f3c98362004da4",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_OwnershipTransferred.json
@@ -17,7 +17,7 @@
             "name": "OwnershipTransferred",
             "type": "event"
         },
-        "contract_address": "0x02d5c618dbc591544b19d0bf13543c0728a3c4ec",
+        "contract_address": "0x7c8719f3683585a242a67c73f6f3c98362004da4",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_ResponseReceived.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_CHF_USD_event_ResponseReceived.json
@@ -22,7 +22,7 @@
             "name": "ResponseReceived",
             "type": "event"
         },
-        "contract_address": "0x02d5c618dbc591544b19d0bf13543c0728a3c4ec",
+        "contract_address": "0x7c8719f3683585a242a67c73f6f3c98362004da4",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_ETH_USD_event_AnswerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_ETH_USD_event_AnswerUpdated.json
@@ -17,7 +17,7 @@
             "name": "AnswerUpdated",
             "type": "event"
         },
-        "contract_address": "0x79febf6b9f76853edbcbc913e6aae8232cfb9de9",
+        "contract_address": "0x37bc7498f4ff12c19678ee8fe19d713b87f6a9e6",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_ETH_USD_event_ChainlinkFulfilled.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_ETH_USD_event_ChainlinkFulfilled.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkFulfilled",
             "type": "event"
         },
-        "contract_address": "0x79febf6b9f76853edbcbc913e6aae8232cfb9de9",
+        "contract_address": "0x37bc7498f4ff12c19678ee8fe19d713b87f6a9e6",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_ETH_USD_event_ChainlinkRequested.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_ETH_USD_event_ChainlinkRequested.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkRequested",
             "type": "event"
         },
-        "contract_address": "0x79febf6b9f76853edbcbc913e6aae8232cfb9de9",
+        "contract_address": "0x37bc7498f4ff12c19678ee8fe19d713b87f6a9e6",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_ETH_USD_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_ETH_USD_event_OwnershipTransferred.json
@@ -17,7 +17,7 @@
             "name": "OwnershipTransferred",
             "type": "event"
         },
-        "contract_address": "0x79febf6b9f76853edbcbc913e6aae8232cfb9de9",
+        "contract_address": "0x37bc7498f4ff12c19678ee8fe19d713b87f6a9e6",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_ETH_USD_event_ResponseReceived.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_ETH_USD_event_ResponseReceived.json
@@ -22,7 +22,7 @@
             "name": "ResponseReceived",
             "type": "event"
         },
-        "contract_address": "0x79febf6b9f76853edbcbc913e6aae8232cfb9de9",
+        "contract_address": "0x37bc7498f4ff12c19678ee8fe19d713b87f6a9e6",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_AnswerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_AnswerUpdated.json
@@ -22,7 +22,7 @@
             "name": "AnswerUpdated",
             "type": "event"
         },
-        "contract_address": "0x25fa978ea1a7dc9bdc33a2959b9053eae57169b5",
+        "contract_address": "0x02f878a94a1ae1b15705acd65b5519a46fe3517e",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_ChainlinkFulfilled.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_ChainlinkFulfilled.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkFulfilled",
             "type": "event"
         },
-        "contract_address": "0x25fa978ea1a7dc9bdc33a2959b9053eae57169b5",
+        "contract_address": "0x02f878a94a1ae1b15705acd65b5519a46fe3517e",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_ChainlinkRequested.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_ChainlinkRequested.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkRequested",
             "type": "event"
         },
-        "contract_address": "0x25fa978ea1a7dc9bdc33a2959b9053eae57169b5",
+        "contract_address": "0x02f878a94a1ae1b15705acd65b5519a46fe3517e",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_NewRound.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_NewRound.json
@@ -17,7 +17,7 @@
             "name": "NewRound",
             "type": "event"
         },
-        "contract_address": "0x25fa978ea1a7dc9bdc33a2959b9053eae57169b5",
+        "contract_address": "0x02f878a94a1ae1b15705acd65b5519a46fe3517e",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_OwnershipTransferred.json
@@ -17,7 +17,7 @@
             "name": "OwnershipTransferred",
             "type": "event"
         },
-        "contract_address": "0x25fa978ea1a7dc9bdc33a2959b9053eae57169b5",
+        "contract_address": "0x02f878a94a1ae1b15705acd65b5519a46fe3517e",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_ResponseReceived.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_EUR_USD_event_ResponseReceived.json
@@ -22,7 +22,7 @@
             "name": "ResponseReceived",
             "type": "event"
         },
-        "contract_address": "0x25fa978ea1a7dc9bdc33a2959b9053eae57169b5",
+        "contract_address": "0x02f878a94a1ae1b15705acd65b5519a46fe3517e",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_AnswerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_AnswerUpdated.json
@@ -22,7 +22,7 @@
             "name": "AnswerUpdated",
             "type": "event"
         },
-        "contract_address": "0x151445852b0cfdf6a4cc81440f2af99176e8ad08",
+        "contract_address": "0x568b8fd03992f56bf240958d22f5a6fcf7bd850b",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_ChainlinkFulfilled.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_ChainlinkFulfilled.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkFulfilled",
             "type": "event"
         },
-        "contract_address": "0x151445852b0cfdf6a4cc81440f2af99176e8ad08",
+        "contract_address": "0x568b8fd03992f56bf240958d22f5a6fcf7bd850b",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_ChainlinkRequested.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_ChainlinkRequested.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkRequested",
             "type": "event"
         },
-        "contract_address": "0x151445852b0cfdf6a4cc81440f2af99176e8ad08",
+        "contract_address": "0x568b8fd03992f56bf240958d22f5a6fcf7bd850b",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_NewRound.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_NewRound.json
@@ -17,7 +17,7 @@
             "name": "NewRound",
             "type": "event"
         },
-        "contract_address": "0x151445852b0cfdf6a4cc81440f2af99176e8ad08",
+        "contract_address": "0x568b8fd03992f56bf240958d22f5a6fcf7bd850b",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_OwnershipTransferred.json
@@ -17,7 +17,7 @@
             "name": "OwnershipTransferred",
             "type": "event"
         },
-        "contract_address": "0x151445852b0cfdf6a4cc81440f2af99176e8ad08",
+        "contract_address": "0x568b8fd03992f56bf240958d22f5a6fcf7bd850b",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_ResponseReceived.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_GBP_USD_event_ResponseReceived.json
@@ -22,7 +22,7 @@
             "name": "ResponseReceived",
             "type": "event"
         },
-        "contract_address": "0x151445852b0cfdf6a4cc81440f2af99176e8ad08",
+        "contract_address": "0x568b8fd03992f56bf240958d22f5a6fcf7bd850b",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_AnswerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_AnswerUpdated.json
@@ -22,7 +22,7 @@
             "name": "AnswerUpdated",
             "type": "event"
         },
-        "contract_address": "0xe1407bfaa6b5965bad1c9f38316a3b655a09d8a6",
+        "contract_address": "0x01a1f73b1f4726eb6eb189ffa5cbb91af8e14025",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_ChainlinkFulfilled.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_ChainlinkFulfilled.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkFulfilled",
             "type": "event"
         },
-        "contract_address": "0xe1407bfaa6b5965bad1c9f38316a3b655a09d8a6",
+        "contract_address": "0x01a1f73b1f4726eb6eb189ffa5cbb91af8e14025",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_ChainlinkRequested.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_ChainlinkRequested.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkRequested",
             "type": "event"
         },
-        "contract_address": "0xe1407bfaa6b5965bad1c9f38316a3b655a09d8a6",
+        "contract_address": "0x01a1f73b1f4726eb6eb189ffa5cbb91af8e14025",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_NewRound.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_NewRound.json
@@ -17,7 +17,7 @@
             "name": "NewRound",
             "type": "event"
         },
-        "contract_address": "0xe1407bfaa6b5965bad1c9f38316a3b655a09d8a6",
+        "contract_address": "0x01a1f73b1f4726eb6eb189ffa5cbb91af8e14025",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_OwnershipTransferred.json
@@ -17,7 +17,7 @@
             "name": "OwnershipTransferred",
             "type": "event"
         },
-        "contract_address": "0xe1407bfaa6b5965bad1c9f38316a3b655a09d8a6",
+        "contract_address": "0x01a1f73b1f4726eb6eb189ffa5cbb91af8e14025",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_ResponseReceived.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_JPY_USD_event_ResponseReceived.json
@@ -22,7 +22,7 @@
             "name": "ResponseReceived",
             "type": "event"
         },
-        "contract_address": "0xe1407bfaa6b5965bad1c9f38316a3b655a09d8a6",
+        "contract_address": "0x01a1f73b1f4726eb6eb189ffa5cbb91af8e14025",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_AnswerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_AnswerUpdated.json
@@ -22,7 +22,7 @@
             "name": "AnswerUpdated",
             "type": "event"
         },
-        "contract_address": "0x8946a183bfafa95becf57c5e08fe5b7654d2807b",
+        "contract_address": "0xdeb43523e2857b7ec29d078c77b73709d958c62f",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_ChainlinkFulfilled.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_ChainlinkFulfilled.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkFulfilled",
             "type": "event"
         },
-        "contract_address": "0x8946a183bfafa95becf57c5e08fe5b7654d2807b",
+        "contract_address": "0xdeb43523e2857b7ec29d078c77b73709d958c62f",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_ChainlinkRequested.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_ChainlinkRequested.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkRequested",
             "type": "event"
         },
-        "contract_address": "0x8946a183bfafa95becf57c5e08fe5b7654d2807b",
+        "contract_address": "0xdeb43523e2857b7ec29d078c77b73709d958c62f",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_NewRound.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_NewRound.json
@@ -17,7 +17,7 @@
             "name": "NewRound",
             "type": "event"
         },
-        "contract_address": "0x8946a183bfafa95becf57c5e08fe5b7654d2807b",
+        "contract_address": "0xdeb43523e2857b7ec29d078c77b73709d958c62f",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_OwnershipTransferred.json
@@ -17,7 +17,7 @@
             "name": "OwnershipTransferred",
             "type": "event"
         },
-        "contract_address": "0x8946a183bfafa95becf57c5e08fe5b7654d2807b",
+        "contract_address": "0xdeb43523e2857b7ec29d078c77b73709d958c62f",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_ResponseReceived.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAG_USD_event_ResponseReceived.json
@@ -22,7 +22,7 @@
             "name": "ResponseReceived",
             "type": "event"
         },
-        "contract_address": "0x8946a183bfafa95becf57c5e08fe5b7654d2807b",
+        "contract_address": "0xdeb43523e2857b7ec29d078c77b73709d958c62f",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_AnswerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_AnswerUpdated.json
@@ -22,7 +22,7 @@
             "name": "AnswerUpdated",
             "type": "event"
         },
-        "contract_address": "0xafce0c7b7fe3425adb3871eae5c0ec6d93e01935",
+        "contract_address": "0xea5f70faa03f5c30b96029635c8d431d1a3cd1b8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_ChainlinkFulfilled.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_ChainlinkFulfilled.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkFulfilled",
             "type": "event"
         },
-        "contract_address": "0xafce0c7b7fe3425adb3871eae5c0ec6d93e01935",
+        "contract_address": "0xea5f70faa03f5c30b96029635c8d431d1a3cd1b8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_ChainlinkRequested.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_ChainlinkRequested.json
@@ -12,7 +12,7 @@
             "name": "ChainlinkRequested",
             "type": "event"
         },
-        "contract_address": "0xafce0c7b7fe3425adb3871eae5c0ec6d93e01935",
+        "contract_address": "0xea5f70faa03f5c30b96029635c8d431d1a3cd1b8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_NewRound.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_NewRound.json
@@ -17,7 +17,7 @@
             "name": "NewRound",
             "type": "event"
         },
-        "contract_address": "0xafce0c7b7fe3425adb3871eae5c0ec6d93e01935",
+        "contract_address": "0xea5f70faa03f5c30b96029635c8d431d1a3cd1b8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_OwnershipTransferred.json
@@ -17,7 +17,7 @@
             "name": "OwnershipTransferred",
             "type": "event"
         },
-        "contract_address": "0xafce0c7b7fe3425adb3871eae5c0ec6d93e01935",
+        "contract_address": "0xea5f70faa03f5c30b96029635c8d431d1a3cd1b8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_ResponseReceived.json
+++ b/dags/resources/stages/parse/table_definitions/chainlink/Aggregator_XAU_USD_event_ResponseReceived.json
@@ -22,7 +22,7 @@
             "name": "ResponseReceived",
             "type": "event"
         },
-        "contract_address": "0xafce0c7b7fe3425adb3871eae5c0ec6d93e01935",
+        "contract_address": "0xea5f70faa03f5c30b96029635c8d431d1a3cd1b8",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
Aggregator contracts found by going to https://docs.chain.link/docs/ethereum-addresses/ reading the respective proxy contracts state to find the underlying aggregator contract. These new addresses were swapped in place with

> find . -name '*.json' | xargs perl -pi -e 's/{old_address}/{new_address}/g'

To verify by hand reproduce the steps and make sure its the right contract. Likely this should all be automated at some point. 

Closes #271 