### PR TITLE
Sessions DAG

### DIFF
--- a/dags/ethereum_sessions_dag.py
+++ b/dags/ethereum_sessions_dag.py
@@ -18,7 +18,7 @@ environment = Variable.get('environment', 'prod')
 # airflow DAG
 DAG = build_sessions_dag(
     dag_id='ethereum_sessions_dag',
-    load_dag_id='ethereum_load_dag',
+    output_bucket=Variable.get('ethereum_output_bucket'),
     sql_dir=sql_dir,
     source_project_id='bigquery-public-data',
     source_dataset_name='crypto_ethereum',

--- a/dags/ethereum_sessions_dag.py
+++ b/dags/ethereum_sessions_dag.py
@@ -28,6 +28,6 @@ DAG = build_sessions_dag(
     temp_dataset_name=Variable.get('ethereum_temp_dataset_name', 'crypto_ethereum_temp'),
     # Load DAG should complete by 14:00.
     schedule_interval='0 14 * * *',
-    start_date=datetime(2015, 7, 30),
+    start_date=datetime(2021, 11, 30),
     environment=environment
 )

--- a/dags/ethereum_sessions_dag.py
+++ b/dags/ethereum_sessions_dag.py
@@ -23,7 +23,9 @@ DAG = build_sessions_dag(
     source_project_id='bigquery-public-data',
     source_dataset_name='crypto_ethereum',
     destination_project_id=Variable.get('ethereum_destination_dataset_project_id'),
+    # Variables default to the prod values. Override for dev environment.
     destination_dataset_name=Variable.get('ethereum_destination_dataset_name', 'crypto_ethereum'),
+    temp_dataset_name=Variable.get('ethereum_temp_dataset_name', 'crypto_ethereum_temp'),
     # Load DAG should complete by 14:00.
     schedule_interval='0 14 * * *',
     start_date=datetime(2015, 7, 30),

--- a/dags/ethereum_sessions_dag.py
+++ b/dags/ethereum_sessions_dag.py
@@ -1,0 +1,31 @@
+from __future__ import print_function
+from airflow.models import Variable
+from datetime import datetime
+from ethereumetl_airflow.build_sessions_dag import build_sessions_dag
+
+import logging
+import os
+
+logging.basicConfig()
+logging.getLogger().setLevel(logging.DEBUG)
+
+DAGS_FOLDER = os.environ.get('DAGS_FOLDER', '/home/airflow/gcs/dags')
+sql_dir = os.path.join(DAGS_FOLDER, 'resources/stages/sessions/sqls')
+
+environment = Variable.get('environment', 'prod')
+
+
+# airflow DAG
+DAG = build_sessions_dag(
+    dag_id='ethereum_sessions_dag',
+    load_dag_id='ethereum_load_dag',
+    sql_dir=sql_dir,
+    source_project_id='bigquery-public-data',
+    source_dataset_name='crypto_ethereum',
+    destination_project_id='crypto-etl-public-data-dev',  # blockchain-etl-internal
+    destination_dataset_name='sessions',
+    # Load DAG should complete by 14:00.
+    schedule_interval='0 14 * * *',
+    start_date=datetime(2015, 7, 30),
+    environment=environment
+)

--- a/dags/ethereum_sessions_dag.py
+++ b/dags/ethereum_sessions_dag.py
@@ -22,8 +22,8 @@ DAG = build_sessions_dag(
     sql_dir=sql_dir,
     source_project_id='bigquery-public-data',
     source_dataset_name='crypto_ethereum',
-    destination_project_id='crypto-etl-public-data-dev',  # blockchain-etl-internal
-    destination_dataset_name='sessions',
+    destination_project_id=Variable.get('ethereum_destination_dataset_project_id'),
+    destination_dataset_name=Variable.get('ethereum_destination_dataset_name', 'crypto_ethereum'),
     # Load DAG should complete by 14:00.
     schedule_interval='0 14 * * *',
     start_date=datetime(2015, 7, 30),

--- a/dags/ethereumetl_airflow/build_sessions_dag.py
+++ b/dags/ethereumetl_airflow/build_sessions_dag.py
@@ -1,0 +1,122 @@
+from __future__ import print_function
+
+import logging
+import os
+
+from airflow import models
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.sensors import ExternalTaskSensor
+from datetime import datetime, timedelta
+from google.cloud import bigquery
+
+logging.basicConfig()
+logging.getLogger().setLevel(logging.DEBUG)
+
+
+def build_sessions_dag(
+        dag_id,
+        load_dag_id,
+        sql_dir,
+        source_project_id,
+        source_dataset_name,
+        destination_project_id,
+        destination_dataset_name,
+        notification_emails=None,
+        schedule_interval='0 14 * * *',
+        start_date=datetime(2015, 7, 30),
+        environment='prod'
+):
+
+    default_dag_args = {
+        'depends_on_past': False,
+        'start_date': start_date,
+        'email_on_failure': True,
+        'email_on_retry': False,
+        'retries': 5,
+        'retry_delay': timedelta(minutes=5)
+    }
+
+    if notification_emails and len(notification_emails) > 0:
+        default_dag_args['email'] = [email.strip() for email in notification_emails.split(',')]
+
+    # Define a DAG (directed acyclic graph) of tasks.
+    dag = models.DAG(
+        dag_id,
+        catchup=True,
+        schedule_interval=schedule_interval,
+        default_args=default_dag_args)
+
+    def read_file(filepath):
+        with open(filepath) as file_handle:
+            content = file_handle.read()
+            return content
+
+    def add_sessions_task(task, dependencies=None):
+        def sessions_task(ds, **kwargs):
+
+            client = bigquery.Client()
+            sql_path = os.path.join(sql_dir, '{task}.sql'.format(task=task))
+            sql_template = read_file(sql_path)
+            ds_no_dashes = ds.replace('-', '')
+            sql = sql_template.format(
+                ds=ds,
+                ds_no_dashes=ds_no_dashes,
+                source_project_id=source_project_id,
+                source_dataset_name=source_dataset_name,
+                destination_project_id=destination_project_id,
+                destination_dataset_name=destination_dataset_name,
+            )
+            print(sql)
+            query_job = client.query(sql)
+            result = query_job.result()
+            logging.info(result)
+
+        sessions_operator = PythonOperator(
+            task_id=f'{task}',
+            # Necessary because we use traces overlapping the previous execution date.
+            depends_on_past=True,
+            wait_for_downstream=True,
+            python_callable=sessions_task,
+            provide_context=True,
+            execution_timeout=timedelta(minutes=60),
+            dag=dag
+        )
+
+        if dependencies is not None and len(dependencies) > 0:
+            for dependency in dependencies:
+                dependency >> sessions_operator
+        return sessions_operator
+
+    stage_root_call_traces_task = add_sessions_task('root_call_traces')
+    upsert_sessions_task = add_sessions_task('sessions')
+
+    # Dummy task indicating successful DAG completion.
+    done_task = BashOperator(
+        task_id='done',
+        bash_command='echo done',
+        dag=dag
+    )
+
+    #
+    # Task sensor is enabled only in production for now because our load DAG is
+    # not running in the lower environments.
+    #
+    if environment == 'prod':
+        wait_for_ethereum_load_dag_task = ExternalTaskSensor(
+            task_id='wait_for_ethereum_load_dag',
+            external_dag_id=load_dag_id,
+            external_task_id='send_email', # Task sends a notification on DAG completion.
+            execution_delta=timedelta(hours=1),
+            priority_weight=0,
+            mode='reschedule',
+            poke_interval=5 * 60,
+            timeout=60 * 60 * 12,
+            dag=dag
+        )
+        wait_for_ethereum_load_dag_task >> stage_root_call_traces_task
+
+    stage_root_call_traces_task >> upsert_sessions_task
+    upsert_sessions_task >> done_task
+
+    return dag

--- a/dags/ethereumetl_airflow/build_sessions_dag.py
+++ b/dags/ethereumetl_airflow/build_sessions_dag.py
@@ -46,6 +46,7 @@ def build_sessions_dag(
         dag_id,
         catchup=True,
         schedule_interval=schedule_interval,
+        max_active_runs=1,
         default_args=default_dag_args)
 
     def read_file(filepath):

--- a/dags/ethereumetl_airflow/build_sessions_dag.py
+++ b/dags/ethereumetl_airflow/build_sessions_dag.py
@@ -22,6 +22,7 @@ def build_sessions_dag(
         source_dataset_name,
         destination_project_id,
         destination_dataset_name,
+        temp_dataset_name,
         notification_emails=None,
         schedule_interval='0 14 * * *',
         start_date=datetime(2015, 7, 30),
@@ -66,6 +67,7 @@ def build_sessions_dag(
                 source_dataset_name=source_dataset_name,
                 destination_project_id=destination_project_id,
                 destination_dataset_name=destination_dataset_name,
+                temp_dataset_name=temp_dataset_name,
             )
             print(sql)
             query_job = client.query(sql)

--- a/dags/resources/stages/sessions/sqls/root_call_traces.sql
+++ b/dags/resources/stages/sessions/sqls/root_call_traces.sql
@@ -1,6 +1,4 @@
-DROP TABLE If EXISTS `{destination_project_id}.{destination_dataset_name}.stage_root_call_traces_{ds_no_dashes}`;
-
-CREATE TABLE `{destination_project_id}.{destination_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
+CREATE OR REPLACE TABLE `{destination_project_id}.{destination_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
 (
   trace_id           STRING,
   wallet_address     STRING    NOT NULL,

--- a/dags/resources/stages/sessions/sqls/root_call_traces.sql
+++ b/dags/resources/stages/sessions/sqls/root_call_traces.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE TABLE `{destination_project_id}.{destination_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
+CREATE OR REPLACE TABLE `{destination_project_id}.{temp_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
 (
   trace_id           STRING,
   wallet_address     STRING    NOT NULL,

--- a/dags/resources/stages/sessions/sqls/root_call_traces.sql
+++ b/dags/resources/stages/sessions/sqls/root_call_traces.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE TABLE `{destination_project_id}.{temp_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
+CREATE OR REPLACE TABLE `{temp_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
 (
   trace_id           STRING,
   wallet_address     STRING    NOT NULL,

--- a/dags/resources/stages/sessions/sqls/root_call_traces.sql
+++ b/dags/resources/stages/sessions/sqls/root_call_traces.sql
@@ -1,0 +1,64 @@
+DROP TABLE If EXISTS `{destination_project_id}.{destination_dataset_name}.stage_root_call_traces_{ds_no_dashes}`;
+
+CREATE TABLE `{destination_project_id}.{destination_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
+(
+  trace_id           STRING,
+  wallet_address     STRING    NOT NULL,
+  contract_address   STRING,
+  inactivity_minutes INT64,
+  transaction_hash   STRING    NOT NULL,
+  block_timestamp    TIMESTAMP NOT NULL,
+  block_hash         STRING    NOT NULL,
+  block_number       INT64     NOT NULL,
+  value              NUMERIC,
+  gas                INT64,
+  gas_used           INT64,
+  trace_type         STRING    NOT NULL,
+  call_type          STRING,
+  error              STRING,
+  status             INT64
+)
+AS
+SELECT
+  traces.trace_id        AS trace_id,
+  traces.from_address    AS wallet_address,
+  traces.to_address      AS contract_address,
+
+   DATETIME_DIFF(
+    traces.block_timestamp,
+    LAG(traces.block_timestamp) OVER (
+      PARTITION BY traces.from_address, traces.to_address
+      ORDER BY traces.block_timestamp ASC
+    ),
+    MINUTE
+  )
+                          AS inactivity_minutes,
+
+  traces.transaction_hash AS transaction_hash,
+  traces.block_timestamp  AS block_timestamp,
+  traces.block_hash       AS block_hash,
+  traces.block_number     AS block_number,
+
+  value                   AS value,
+  gas                     AS gas,
+  gas_used                AS gas_used,
+  trace_type              AS trace_type,
+  call_type               AS call_type,
+  error                   AS error,
+  status                  AS status
+FROM
+  `{source_project_id}.{source_dataset_name}`.traces AS traces
+WHERE
+  -- Only use traces corresponding to the root of the call stack. See openethereum docs:
+  -- https://openethereum.github.io/JSONRPC-trace-module
+  trace_address IS NULL
+  -- "call" traces log transfers of ether from one account to another and/or calls to a
+  -- smart contract function defined by parameters in the data field. This trace also
+  -- encompasses delegatecall and callcode.
+  AND trace_type = 'call'
+  -- Use traces overlapping the previous partition so we can extend existing sessions.
+  AND block_timestamp >= timestamp_add(TIMESTAMP '{ds}', INTERVAL -30 MINUTE)
+  AND block_timestamp < timestamp_add(TIMESTAMP '{ds}', INTERVAL 1 DAY)
+ORDER BY
+  wallet_address,
+  block_timestamp ASC;

--- a/dags/resources/stages/sessions/sqls/sessions.sql
+++ b/dags/resources/stages/sessions/sqls/sessions.sql
@@ -6,6 +6,7 @@ CREATE TEMPORARY TABLE `stage_sessions_{ds_no_dashes}`
   start_block_timestamp              TIMESTAMP NOT NULL,
   wallet_address                     STRING    NOT NULL,
   contract_address                   STRING,
+  -- TODO: Drop this column.
   next_session_start_block_timestamp TIMESTAMP
 );
 
@@ -33,7 +34,7 @@ SELECT
                     AS next_session_start_block_timestamp
 
 FROM
-  `{destination_project_id}.{destination_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
+  `{destination_project_id}.{temp_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
 WHERE
   -- Greater than 30 minutes of inactivity defines a new session.
   (inactivity_minutes > 30 OR inactivity_minutes IS NULL)
@@ -76,4 +77,4 @@ DELETE;
 DROP TABLE `stage_sessions_{ds_no_dashes}`;
 
 -- Drop staging table for root call traces.
-DROP TABLE `{destination_project_id}.{destination_dataset_name}.stage_root_call_traces_{ds_no_dashes}`;
+DROP TABLE `{destination_project_id}.{temp_dataset_name}.stage_root_call_traces_{ds_no_dashes}`;

--- a/dags/resources/stages/sessions/sqls/sessions.sql
+++ b/dags/resources/stages/sessions/sqls/sessions.sql
@@ -31,7 +31,7 @@ WHERE
   (inactivity_minutes > 30 OR inactivity_minutes IS NULL)
   -- Only create new sessions using traces in the current execution date partition.
   -- This is necessary because the staging table overlaps the previous partition.
-  AND date(block_timestamp) = date('{ds}');
+  AND date(block_timestamp) = '{ds}';
 
 
 -- Create the sessions table if necessary.
@@ -43,7 +43,7 @@ LIKE `stage_sessions_{ds_no_dashes}`;
 MERGE INTO `{destination_project_id}.{destination_dataset_name}.sessions` AS target
 USING `stage_sessions_{ds_no_dashes}` AS source
 ON false
-WHEN NOT MATCHED AND date(start_block_timestamp) = date('{ds}') THEN
+WHEN NOT MATCHED AND date(start_block_timestamp) = '{ds}' THEN
 INSERT (
   id,
   start_block_number,
@@ -58,7 +58,7 @@ VALUES (
   wallet_address,
   contract_address
 )
-WHEN NOT MATCHED BY SOURCE AND date(start_block_timestamp) = date('{ds}') THEN
+WHEN NOT MATCHED BY SOURCE AND date(start_block_timestamp) = '{ds}' THEN
 DELETE;
 
 

--- a/dags/resources/stages/sessions/sqls/sessions.sql
+++ b/dags/resources/stages/sessions/sqls/sessions.sql
@@ -1,5 +1,5 @@
 -- Create a staging table.
-CREATE TABLE `{temp_dataset_name}.stage_sessions_{ds_no_dashes}`
+CREATE OR REPLACE TABLE `{temp_dataset_name}.stage_sessions_{ds_no_dashes}`
 (
   id                                 STRING    NOT NULL,
   start_trace_id                     STRING    NOT NULL,

--- a/dags/resources/stages/sessions/sqls/sessions.sql
+++ b/dags/resources/stages/sessions/sqls/sessions.sql
@@ -74,3 +74,6 @@ DELETE;
 
 -- Delete the temporary table.
 DROP TABLE `stage_sessions_{ds_no_dashes}`;
+
+-- Drop staging table for root call traces.
+DROP TABLE `{destination_project_id}.{destination_dataset_name}.stage_root_call_traces_{ds_no_dashes}`;

--- a/dags/resources/stages/sessions/sqls/sessions.sql
+++ b/dags/resources/stages/sessions/sqls/sessions.sql
@@ -1,5 +1,5 @@
 -- Create a staging table.
-CREATE TEMPORARY TABLE `stage_sessions_{ds_no_dashes}`
+CREATE TABLE `{temp_dataset_name}.stage_sessions_{ds_no_dashes}`
 (
   id                                 STRING    NOT NULL,
   start_block_number                 INT64     NOT NULL,
@@ -10,7 +10,7 @@ CREATE TEMPORARY TABLE `stage_sessions_{ds_no_dashes}`
 
 
 -- Stage sessions for this execution date.
-INSERT INTO `stage_sessions_{ds_no_dashes}`
+INSERT INTO `{temp_dataset_name}.stage_sessions_{ds_no_dashes}`
 SELECT
   TO_HEX(MD5(CONCAT(
     trace_id,
@@ -36,12 +36,12 @@ WHERE
 
 -- Create the sessions table if necessary.
 CREATE TABLE IF NOT EXISTS `{destination_project_id}.{destination_dataset_name}.sessions`
-LIKE `stage_sessions_{ds_no_dashes}`;
+LIKE `{temp_dataset_name}.stage_sessions_{ds_no_dashes}`;
 
 
 -- Merge staging table with destination table.
 MERGE INTO `{destination_project_id}.{destination_dataset_name}.sessions` AS target
-USING `stage_sessions_{ds_no_dashes}` AS source
+USING `{temp_dataset_name}.stage_sessions_{ds_no_dashes}` AS source
 ON false
 WHEN NOT MATCHED AND date(start_block_timestamp) = '{ds}' THEN
 INSERT (
@@ -63,7 +63,7 @@ DELETE;
 
 
 -- Delete the temporary table.
-DROP TABLE `stage_sessions_{ds_no_dashes}`;
+DROP TABLE `{temp_dataset_name}.stage_sessions_{ds_no_dashes}`;
 
 -- Drop staging table for root call traces.
-DROP TABLE `{destination_project_id}.{temp_dataset_name}.stage_root_call_traces_{ds_no_dashes}`;
+DROP TABLE `{temp_dataset_name}.stage_root_call_traces_{ds_no_dashes}`;

--- a/dags/resources/stages/sessions/sqls/sessions.sql
+++ b/dags/resources/stages/sessions/sqls/sessions.sql
@@ -2,6 +2,7 @@
 CREATE TABLE `{temp_dataset_name}.stage_sessions_{ds_no_dashes}`
 (
   id                                 STRING    NOT NULL,
+  start_trace_id                     STRING    NOT NULL,
   start_block_number                 INT64     NOT NULL,
   start_block_timestamp              TIMESTAMP NOT NULL,
   wallet_address                     STRING    NOT NULL,
@@ -20,6 +21,7 @@ SELECT
   )))
                     AS id,
 
+  trace_id          AS start_trace_id,
   block_number      AS start_block_number,
   block_timestamp   AS start_block_timestamp,
   wallet_address    AS wallet_address,
@@ -46,6 +48,7 @@ ON false
 WHEN NOT MATCHED AND date(start_block_timestamp) = '{ds}' THEN
 INSERT (
   id,
+  start_trace_id,
   start_block_number,
   start_block_timestamp,
   wallet_address,
@@ -53,6 +56,7 @@ INSERT (
 )
 VALUES (
   id,
+  start_trace_id,
   start_block_number,
   start_block_timestamp,
   wallet_address,

--- a/dags/resources/stages/sessions/sqls/sessions.sql
+++ b/dags/resources/stages/sessions/sqls/sessions.sql
@@ -5,9 +5,7 @@ CREATE TEMPORARY TABLE `stage_sessions_{ds_no_dashes}`
   start_block_number                 INT64     NOT NULL,
   start_block_timestamp              TIMESTAMP NOT NULL,
   wallet_address                     STRING    NOT NULL,
-  contract_address                   STRING,
-  -- TODO: Drop this column.
-  next_session_start_block_timestamp TIMESTAMP
+  contract_address                   STRING
 );
 
 
@@ -25,14 +23,7 @@ SELECT
   block_number      AS start_block_number,
   block_timestamp   AS start_block_timestamp,
   wallet_address    AS wallet_address,
-  contract_address  AS contract_address,
-
-  LEAD(block_timestamp) OVER (
-    PARTITION BY wallet_address, contract_address
-    ORDER BY block_timestamp ASC
-  )
-                    AS next_session_start_block_timestamp
-
+  contract_address  AS contract_address
 FROM
   `{destination_project_id}.{temp_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
 WHERE
@@ -58,16 +49,14 @@ INSERT (
   start_block_number,
   start_block_timestamp,
   wallet_address,
-  contract_address,
-  next_session_start_block_timestamp
+  contract_address
 )
 VALUES (
   id,
   start_block_number,
   start_block_timestamp,
   wallet_address,
-  contract_address,
-  next_session_start_block_timestamp
+  contract_address
 )
 WHEN NOT MATCHED BY SOURCE AND date(start_block_timestamp) = date('{ds}') THEN
 DELETE;

--- a/dags/resources/stages/sessions/sqls/sessions.sql
+++ b/dags/resources/stages/sessions/sqls/sessions.sql
@@ -25,7 +25,7 @@ SELECT
   wallet_address    AS wallet_address,
   contract_address  AS contract_address
 FROM
-  `{destination_project_id}.{temp_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
+  `{temp_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
 WHERE
   -- Greater than 30 minutes of inactivity defines a new session.
   (inactivity_minutes > 30 OR inactivity_minutes IS NULL)

--- a/dags/resources/stages/sessions/sqls/sessions.sql
+++ b/dags/resources/stages/sessions/sqls/sessions.sql
@@ -1,0 +1,76 @@
+-- Create a staging table.
+CREATE TEMPORARY TABLE `stage_sessions_{ds_no_dashes}`
+(
+  id                                 STRING    NOT NULL,
+  start_block_number                 INT64     NOT NULL,
+  start_block_timestamp              TIMESTAMP NOT NULL,
+  wallet_address                     STRING    NOT NULL,
+  contract_address                   STRING,
+  next_session_start_block_timestamp TIMESTAMP
+);
+
+
+-- Stage sessions for this execution date.
+INSERT INTO `stage_sessions_{ds_no_dashes}`
+SELECT
+  TO_HEX(MD5(CONCAT(
+    trace_id,
+    wallet_address,
+    contract_address,
+    block_timestamp
+  )))
+                    AS id,
+
+  block_number      AS start_block_number,
+  block_timestamp   AS start_block_timestamp,
+  wallet_address    AS wallet_address,
+  contract_address  AS contract_address,
+
+  LEAD(block_timestamp) OVER (
+    PARTITION BY wallet_address, contract_address
+    ORDER BY block_timestamp ASC
+  )
+                    AS next_session_start_block_timestamp
+
+FROM
+  `{destination_project_id}.{destination_dataset_name}.stage_root_call_traces_{ds_no_dashes}`
+WHERE
+  -- Greater than 30 minutes of inactivity defines a new session.
+  (inactivity_minutes > 30 OR inactivity_minutes IS NULL)
+  -- Only create new sessions using traces in the current execution date partition.
+  -- This is necessary because the staging table overlaps the previous partition.
+  AND date(block_timestamp) = date('{ds}');
+
+
+-- Create the sessions table if necessary.
+CREATE TABLE IF NOT EXISTS `{destination_project_id}.{destination_dataset_name}.sessions`
+LIKE `stage_sessions_{ds_no_dashes}`;
+
+
+-- Merge staging table with destination table.
+MERGE INTO `{destination_project_id}.{destination_dataset_name}.sessions` AS target
+USING `stage_sessions_{ds_no_dashes}` AS source
+ON false
+WHEN NOT MATCHED AND date(start_block_timestamp) = date('{ds}') THEN
+INSERT (
+  id,
+  start_block_number,
+  start_block_timestamp,
+  wallet_address,
+  contract_address,
+  next_session_start_block_timestamp
+)
+VALUES (
+  id,
+  start_block_number,
+  start_block_timestamp,
+  wallet_address,
+  contract_address,
+  next_session_start_block_timestamp
+)
+WHEN NOT MATCHED BY SOURCE AND date(start_block_timestamp) = date('{ds}') THEN
+DELETE;
+
+
+-- Delete the temporary table.
+DROP TABLE `stage_sessions_{ds_no_dashes}`;


### PR DESCRIPTION
This PR adds a `ethereum_sessions_dag` DAG and corresponding `sessions` table to the `crypto_ethereum` dataset.  It builds on the work started in the [blockchain-etl/data-studio-connectors repo](https://github.com/blockchain-etl/data-studio-connectors) to extend the concept of a web analytics session to smart contracts.

I'm seeking initial feedback on at least the following aspects of this code:

1.  There's a staging table used in each DAG run for the "root call traces".  Should this be materialized in this manner within the destination dataset (`crypto_ethereum` in prod)?  Or is there a alternative way this should be done?

2. The DAG triggers at `14:00` daily and will start with the `wait_for_ethereum_load_dag` task.   This is also how the partitioned DAG is scheduled.  Is this a good way to schedule it? 