### PR TITLE
Add events of new OpenSea contract

### DIFF
--- a/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_NonceIncremented.json
+++ b/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_NonceIncremented.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newNonce",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NonceIncremented",
+            "type": "event"
+        },
+        "contract_address": "0x7f268357a8c2552623316e2562d90e642bb538e5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "opensea",
+        "schema": [
+            {
+                "description": "",
+                "name": "maker",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newNonce",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WyvernExchangeWithBulkCancellations_event_NonceIncremented"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OrderApprovedPartOne.json
+++ b/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OrderApprovedPartOne.json
@@ -1,0 +1,151 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "hash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "exchange",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "makerRelayerFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "takerRelayerFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "makerProtocolFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "takerProtocolFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "name": "feeRecipient",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "feeMethod",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "name": "side",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "name": "saleKind",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "name": "target",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderApprovedPartOne",
+            "type": "event"
+        },
+        "contract_address": "0x7f268357a8c2552623316e2562d90e642bb538e5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "opensea",
+        "schema": [
+            {
+                "description": "",
+                "name": "hash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "exchange",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "maker",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "taker",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "makerRelayerFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "takerRelayerFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "makerProtocolFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "takerProtocolFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeRecipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeMethod",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "side",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "saleKind",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "target",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WyvernExchangeWithBulkCancellations_event_OrderApprovedPartOne"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OrderApprovedPartTwo.json
+++ b/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OrderApprovedPartTwo.json
@@ -1,0 +1,151 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "hash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "howToCall",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "name": "calldata",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "replacementPattern",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "staticTarget",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "staticExtradata",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "paymentToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "basePrice",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "extra",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "listingTime",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "expirationTime",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "salt",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "orderbookInclusionDesired",
+                    "type": "bool"
+                }
+            ],
+            "name": "OrderApprovedPartTwo",
+            "type": "event"
+        },
+        "contract_address": "0x7f268357a8c2552623316e2562d90e642bb538e5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "opensea",
+        "schema": [
+            {
+                "description": "",
+                "name": "hash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "howToCall",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "calldata",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "replacementPattern",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "staticTarget",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "staticExtradata",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "paymentToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "basePrice",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "extra",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "listingTime",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "expirationTime",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "salt",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "orderbookInclusionDesired",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WyvernExchangeWithBulkCancellations_event_OrderApprovedPartTwo"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OrderCancelled.json
+++ b/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OrderCancelled.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "hash",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "OrderCancelled",
+            "type": "event"
+        },
+        "contract_address": "0x7f268357a8c2552623316e2562d90e642bb538e5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "opensea",
+        "schema": [
+            {
+                "description": "",
+                "name": "hash",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WyvernExchangeWithBulkCancellations_event_OrderCancelled"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OrdersMatched.json
+++ b/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OrdersMatched.json
@@ -1,0 +1,81 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "buyHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "name": "sellHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "price",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "name": "metadata",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "OrdersMatched",
+            "type": "event"
+        },
+        "contract_address": "0x7f268357a8c2552623316e2562d90e642bb538e5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "opensea",
+        "schema": [
+            {
+                "description": "",
+                "name": "buyHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sellHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "maker",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "taker",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "price",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "metadata",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WyvernExchangeWithBulkCancellations_event_OrdersMatched"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OwnershipRenounced.json
+++ b/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OwnershipRenounced.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipRenounced",
+            "type": "event"
+        },
+        "contract_address": "0x7f268357a8c2552623316e2562d90e642bb538e5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "opensea",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WyvernExchangeWithBulkCancellations_event_OwnershipRenounced"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/opensea/WyvernExchangeWithBulkCancellations_event_OwnershipTransferred.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x7f268357a8c2552623316e2562d90e642bb538e5",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "opensea",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "WyvernExchangeWithBulkCancellations_event_OwnershipTransferred"
+    }
+}


### PR DESCRIPTION
OpenSea is going to migrate to a new contract starting tomorrow: https://opensea.io/blog/developers/wyvern-2-3-developer-upgrade-guide/

The events are mostly the same as before.