### PR TITLE
Feature/tornado withdraw deposit events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Deposit.json
@@ -32,7 +32,7 @@
     "table": {
         "dataset_name": "ethereum_tornado",
         "table_name": "ERC20Tornado_event_Deposit",
-        "table_description": "",
+        "table_description": "Deposit events for 10k DAI, 100k DAI, 0.1 WBTC, 1 WBTC and 10 WBTC Tornado Cash Pools",
         "schema": [
             {
                 "name": "commitment",

--- a/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Deposit.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT * FROM UNNEST(['0x07687e702b410fa43f4cb4af7fa097918ffd2730', '0x23773e65ed146a459791799d01336db287f25334', '0x178169b423a011fff22b9e3f3abea13414ddd0f1', '0x610b717796ad172b316836ac95a2ffad065ceab4', '0xbb93e510bbcd0b7beb5a853875f9ec60275cf498'])",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "commitment",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "leafIndex",
+                    "type": "uint32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposit",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ethereum_tornado",
+        "table_name": "ERC20Tornado_event_Deposit",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "commitment",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "leafIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "timestamp",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Deposit.json
@@ -30,7 +30,7 @@
         "field_mapping": {}
     },
     "table": {
-        "dataset_name": "ethereum_tornado",
+        "dataset_name": "tornado",
         "table_name": "ERC20Tornado_event_Deposit",
         "table_description": "Deposit events for 10k DAI, 100k DAI, 0.1 WBTC, 1 WBTC and 10 WBTC Tornado Cash Pools",
         "schema": [

--- a/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Withdrawal.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT * FROM UNNEST(['0x07687e702b410fa43f4cb4af7fa097918ffd2730', '0x23773e65ed146a459791799d01336db287f25334', '0x178169b423a011fff22b9e3f3abea13414ddd0f1', '0x610b717796ad172b316836ac95a2ffad065ceab4', '0xbb93e510bbcd0b7beb5a853875f9ec60275cf498'])",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "nullifierHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "relayer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "fee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdrawal",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ethereum_tornado",
+        "table_name": "ERC20Tornado_event_Withdrawal",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nullifierHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "relayer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fee",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Withdrawal.json
@@ -36,7 +36,7 @@
         "field_mapping": {}
     },
     "table": {
-        "dataset_name": "ethereum_tornado",
+        "dataset_name": "tornado",
         "table_name": "ERC20Tornado_event_Withdrawal",
         "table_description": "Withdrawal events for 10k DAI, 100k DAI, 0.1 WBTC, 1 WBTC and 10 WBTC Tornado Cash Pools",
         "schema": [

--- a/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/ERC20Tornado_event_Withdrawal.json
@@ -38,7 +38,7 @@
     "table": {
         "dataset_name": "ethereum_tornado",
         "table_name": "ERC20Tornado_event_Withdrawal",
-        "table_description": "",
+        "table_description": "Withdrawal events for 10k DAI, 100k DAI, 0.1 WBTC, 1 WBTC and 10 WBTC Tornado Cash Pools",
         "schema": [
             {
                 "name": "to",

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Deposit.json
@@ -30,7 +30,7 @@
         "field_mapping": {}
     },
     "table": {
-        "dataset_name": "ethereum_tornado",
+        "dataset_name": "tornado",
         "table_name": "TornadoCash_Eth_01_event_Deposit",
         "table_description": "Deposit events for 0.1 ETH Tornado Cash Pool",
         "schema": [

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Deposit.json
@@ -32,7 +32,7 @@
     "table": {
         "dataset_name": "ethereum_tornado",
         "table_name": "TornadoCash_Eth_01_event_Deposit",
-        "table_description": "",
+        "table_description": "Deposit events for 0.1 ETH Tornado Cash Pool",
         "schema": [
             {
                 "name": "commitment",

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Deposit.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x12d66f87a04a9e220743712ce6d9bb1b5616b8fc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "commitment",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "leafIndex",
+                    "type": "uint32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposit",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ethereum_tornado",
+        "table_name": "TornadoCash_Eth_01_event_Deposit",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "commitment",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "leafIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "timestamp",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Withdrawal.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0x12d66f87a04a9e220743712ce6d9bb1b5616b8fc",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "nullifierHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "relayer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "fee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdrawal",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ethereum_tornado",
+        "table_name": "TornadoCash_Eth_01_event_Withdrawal",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nullifierHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "relayer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fee",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Withdrawal.json
@@ -38,7 +38,7 @@
     "table": {
         "dataset_name": "ethereum_tornado",
         "table_name": "TornadoCash_Eth_01_event_Withdrawal",
-        "table_description": "",
+        "table_description": "Withdrawal events for 0.1 ETH Tornado Cash Pool",
         "schema": [
             {
                 "name": "to",

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_Eth_01_event_Withdrawal.json
@@ -36,7 +36,7 @@
         "field_mapping": {}
     },
     "table": {
-        "dataset_name": "ethereum_tornado",
+        "dataset_name": "tornado",
         "table_name": "TornadoCash_Eth_01_event_Withdrawal",
         "table_description": "Withdrawal events for 0.1 ETH Tornado Cash Pool",
         "schema": [

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Deposit.json
@@ -32,7 +32,7 @@
     "table": {
         "dataset_name": "ethereum_tornado",
         "table_name": "TornadoCash_erc20_event_Deposit",
-        "table_description": "",
+        "table_description": "Deposit events for 100 DAI, 1k DAI, 5k cDAI, 100 USDC, 1k USDC, 100 USDT and 1k USDT Tornado Cash Pools",
         "schema": [
             {
                 "name": "commitment",

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Deposit.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT * FROM UNNEST(['0xd4b88df4d29f5cedd6857912842cff3b20c8cfa3', '0xfd8610d20aa15b7b2e3be39b396a1bc3516c7144','0xd96f2b1c14db8458374d9aca76e26c3d18364307','0x4736dcf1b7a3d580672cce6e7c65cd5cc9cfba9d','0x169ad27a470d064dede56a2d3ff727986b15d52b','0x0836222f2b2b24a3f36f98668ed8f0b38d1a872f','0x22aaa7720ddd5388a3c0a3333430953c68f1849b'])",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "commitment",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "leafIndex",
+                    "type": "uint32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposit",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ethereum_tornado",
+        "table_name": "TornadoCash_erc20_event_Deposit",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "commitment",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "leafIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "timestamp",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Deposit.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "SELECT * FROM UNNEST(['0xd4b88df4d29f5cedd6857912842cff3b20c8cfa3', '0xfd8610d20aa15b7b2e3be39b396a1bc3516c7144','0xd96f2b1c14db8458374d9aca76e26c3d18364307','0x4736dcf1b7a3d580672cce6e7c65cd5cc9cfba9d','0x169ad27a470d064dede56a2d3ff727986b15d52b','0x0836222f2b2b24a3f36f98668ed8f0b38d1a872f','0x22aaa7720ddd5388a3c0a3333430953c68f1849b'])",
+        "contract_address": "SELECT * FROM UNNEST(['0xd4b88df4d29f5cedd6857912842cff3b20c8cfa3', '0xfd8610d20aa15b7b2e3be39b396a1bc3516c7144', '0xd96f2b1c14db8458374d9aca76e26c3d18364307', '0x4736dcf1b7a3d580672cce6e7c65cd5cc9cfba9d', '0x169ad27a470d064dede56a2d3ff727986b15d52b', '0x0836222f2b2b24a3f36f98668ed8f0b38d1a872f', '0x22aaa7720ddd5388a3c0a3333430953c68f1849b'])",
         "abi": {
             "anonymous": false,
             "inputs": [

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Deposit.json
@@ -30,7 +30,7 @@
         "field_mapping": {}
     },
     "table": {
-        "dataset_name": "ethereum_tornado",
+        "dataset_name": "tornado",
         "table_name": "TornadoCash_erc20_event_Deposit",
         "table_description": "Deposit events for 100 DAI, 1k DAI, 5k cDAI, 100 USDC, 1k USDC, 100 USDT and 1k USDT Tornado Cash Pools",
         "schema": [

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Withdrawal.json
@@ -36,7 +36,7 @@
         "field_mapping": {}
     },
     "table": {
-        "dataset_name": "ethereum_tornado",
+        "dataset_name": "tornado",
         "table_name": "TornadoCash_erc20_event_Withdrawal",
         "table_description": "Withdrawal events for 100 DAI, 1k DAI, 5k cDAI, 100 USDC, 1k USDC, 100 USDT and 1k USDT Tornado Cash Pools",
         "schema": [

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Withdrawal.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT * FROM UNNEST(['0xd4b88df4d29f5cedd6857912842cff3b20c8cfa3', '0xfd8610d20aa15b7b2e3be39b396a1bc3516c7144','0xd96f2b1c14db8458374d9aca76e26c3d18364307','0x4736dcf1b7a3d580672cce6e7c65cd5cc9cfba9d','0x169ad27a470d064dede56a2d3ff727986b15d52b','0x0836222f2b2b24a3f36f98668ed8f0b38d1a872f','0x22aaa7720ddd5388a3c0a3333430953c68f1849b'])",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "nullifierHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "relayer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "fee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdrawal",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ethereum_tornado",
+        "table_name": "TornadoCash_erc20_event_Withdrawal",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nullifierHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "relayer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fee",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Withdrawal.json
@@ -38,7 +38,7 @@
     "table": {
         "dataset_name": "ethereum_tornado",
         "table_name": "TornadoCash_erc20_event_Withdrawal",
-        "table_description": "",
+        "table_description": "Withdrawal events for 100 DAI, 1k DAI, 5k cDAI, 100 USDC, 1k USDC, 100 USDT and 1k USDT Tornado Cash Pools",
         "schema": [
             {
                 "name": "to",

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_erc20_event_Withdrawal.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "SELECT * FROM UNNEST(['0xd4b88df4d29f5cedd6857912842cff3b20c8cfa3', '0xfd8610d20aa15b7b2e3be39b396a1bc3516c7144','0xd96f2b1c14db8458374d9aca76e26c3d18364307','0x4736dcf1b7a3d580672cce6e7c65cd5cc9cfba9d','0x169ad27a470d064dede56a2d3ff727986b15d52b','0x0836222f2b2b24a3f36f98668ed8f0b38d1a872f','0x22aaa7720ddd5388a3c0a3333430953c68f1849b'])",
+        "contract_address": "SELECT * FROM UNNEST(['0xd4b88df4d29f5cedd6857912842cff3b20c8cfa3', '0xfd8610d20aa15b7b2e3be39b396a1bc3516c7144', '0xd96f2b1c14db8458374d9aca76e26c3d18364307', '0x4736dcf1b7a3d580672cce6e7c65cd5cc9cfba9d', '0x169ad27a470d064dede56a2d3ff727986b15d52b', '0x0836222f2b2b24a3f36f98668ed8f0b38d1a872f', '0x22aaa7720ddd5388a3c0a3333430953c68f1849b'])",
         "abi": {
             "anonymous": false,
             "inputs": [

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Deposit.json
@@ -30,7 +30,7 @@
         "field_mapping": {}
     },
     "table": {
-        "dataset_name": "ethereum_tornado",
+        "dataset_name": "tornado",
         "table_name": "TornadoCash_eth_event_Deposit",
         "table_description": "Deposit events for 1 ETH, 10 ETH and 100 ETH Tornado Cash Pools",
         "schema": [

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Deposit.json
@@ -32,7 +32,7 @@
     "table": {
         "dataset_name": "ethereum_tornado",
         "table_name": "TornadoCash_eth_event_Deposit",
-        "table_description": "",
+        "table_description": "Deposit events for 1 ETH, 10 ETH and 100 ETH Tornado Cash Pools",
         "schema": [
             {
                 "name": "commitment",

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Deposit.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT * FROM UNNEST(['0x47ce0c6ed5b0ce3d3a51fdb1c52dc66a7c3c2936', '0x910cbd523d972eb0a6f4cae4618ad62622b39dbf', '0xa160cdab225685da1d56aa342ad8841c3b53f291'])",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "commitment",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "leafIndex",
+                    "type": "uint32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposit",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ethereum_tornado",
+        "table_name": "TornadoCash_eth_event_Deposit",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "commitment",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "leafIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "timestamp",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Withdrawal.json
@@ -38,7 +38,7 @@
     "table": {
         "dataset_name": "ethereum_tornado",
         "table_name": "TornadoCash_eth_event_Withdrawal",
-        "table_description": "",
+        "table_description": "Withdrawal events for 1 ETH, 10 ETH and 100 ETH Tornado Cash Pools",
         "schema": [
             {
                 "name": "to",

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Withdrawal.json
@@ -36,7 +36,7 @@
         "field_mapping": {}
     },
     "table": {
-        "dataset_name": "ethereum_tornado",
+        "dataset_name": "tornado",
         "table_name": "TornadoCash_eth_event_Withdrawal",
         "table_description": "Withdrawal events for 1 ETH, 10 ETH and 100 ETH Tornado Cash Pools",
         "schema": [

--- a/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/TornadoCash_eth_event_Withdrawal.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT * FROM UNNEST(['0x47ce0c6ed5b0ce3d3a51fdb1c52dc66a7c3c2936', '0x910cbd523d972eb0a6f4cae4618ad62622b39dbf', '0xa160cdab225685da1d56aa342ad8841c3b53f291'])",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "nullifierHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "relayer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "fee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdrawal",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ethereum_tornado",
+        "table_name": "TornadoCash_eth_event_Withdrawal",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nullifierHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "relayer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fee",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Deposit.json
@@ -30,7 +30,7 @@
         "field_mapping": {}
     },
     "table": {
-        "dataset_name": "ethereum_tornado",
+        "dataset_name": "tornado",
         "table_name": "cTornado_event_Deposit",
         "table_description": "Deposit events for 50k cDai, 500k cDai and 5 million cDai Tornado Cash pools",
         "schema": [

--- a/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Deposit.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT * FROM UNNEST(['0x03893a7c7463ae47d46bc7f091665f1893656003', '0x2717c5e28cf931547b621a5dddb772ab6a35b701', '0xd21be7248e0197ee08e0c20d4a96debdac3d20af'])",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "commitment",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "leafIndex",
+                    "type": "uint32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposit",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ethereum_tornado",
+        "table_name": "cTornado_event_Deposit",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "commitment",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "leafIndex",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "timestamp",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Deposit.json
@@ -32,7 +32,7 @@
     "table": {
         "dataset_name": "ethereum_tornado",
         "table_name": "cTornado_event_Deposit",
-        "table_description": "",
+        "table_description": "Deposit events for 50k cDai, 500k cDai and 5 million cDai Tornado Cash pools",
         "schema": [
             {
                 "name": "commitment",

--- a/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Withdrawal.json
@@ -36,7 +36,7 @@
         "field_mapping": {}
     },
     "table": {
-        "dataset_name": "ethereum_tornado",
+        "dataset_name": "tornado",
         "table_name": "cTornado_event_Withdrawal",
         "table_description": "Withrawal events for 50k cDai, 500k cDai and 5 million cDai Tornado Cash pools",
         "schema": [

--- a/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Withdrawal.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "SELECT * FROM UNNEST(['0x03893a7c7463ae47d46bc7f091665f1893656003', '0x2717c5e28cf931547b621a5dddb772ab6a35b701', '0xd21be7248e0197ee08e0c20d4a96debdac3d20af'])",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "nullifierHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "relayer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "fee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdrawal",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "ethereum_tornado",
+        "table_name": "cTornado_event_Withdrawal",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "to",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nullifierHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "relayer",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fee",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Withdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/tornado/cTornado_event_Withdrawal.json
@@ -38,7 +38,7 @@
     "table": {
         "dataset_name": "ethereum_tornado",
         "table_name": "cTornado_event_Withdrawal",
-        "table_description": "",
+        "table_description": "Withrawal events for 50k cDai, 500k cDai and 5 million cDai Tornado Cash pools",
         "schema": [
             {
                 "name": "to",


### PR DESCRIPTION
Added table definitions for Tornado Cash Withdrawal and Deposit events using Table Definition CLI Tool
    
Currently there are two tables for Tornado withdraw/deposit events:
- ethereum_tornado.TornadoCash_event_Withdrawal
- ethereum_tornado.TornadoCash_event_Deposit
These are only tracking the 10ETH pool ( 0x910cbd523d972eb0a6f4cae4618ad62622b39dbf )

The tables added in this commit track withdrawals and deposits for all 19 pools found at https://docs.tornado.cash/general/tornado-cash-smart-contracts 
There are 5 different abi between the 19 pools and tables were named according to the contract name.

(The 10ETH pool data is included in the TornadoCash_eth_event_* tables which should make the current 2 tables redundant)