### PR TITLE
Add ERC721 and ERC1155 Order Filled events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderCancelled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderCancelled.json
@@ -30,12 +30,12 @@
         "schema": [
             {
                 "name": "maker",
-                "description": "",
+                "description": "The maker of the order.",
                 "type": "STRING"
             },
             {
                 "name": "nonce",
-                "description": "",
+                "description": "The nonce of the order that was cancelled.",
                 "type": "STRING"
             }
         ]

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderCancelled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderCancelled.json
@@ -26,7 +26,7 @@
     "table": {
         "dataset_name": "zeroex",
         "table_name": "Exchange_v4_0_event_ERC1155OrderCancelled",
-        "table_description": "",
+        "table_description": "Emitted whenever an `ERC1155Order` is canceled.",
         "schema": [
             {
                 "name": "maker",
@@ -35,7 +35,7 @@
             },
             {
                 "name": "nonce",
-                "description": "Emitted whenever an `ERC1155Order` is canceled.",
+                "description": "",
                 "type": "STRING"
             }
         ]

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderCancelled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderCancelled.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC1155OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v4_0_event_ERC1155OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "Emitted whenever an `ERC1155Order` is canceled.",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderFilled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderFilled.json
@@ -74,7 +74,7 @@
     "table": {
         "dataset_name": "zeroex",
         "table_name": "Exchange_v4_0_event_ERC1155OrderFilled",
-        "table_description": "",
+        "table_description": "Emitted whenever an `ERC1155Order` is filled.",
         "schema": [
             {
                 "name": "direction",
@@ -123,7 +123,7 @@
             },
             {
                 "name": "matcher",
-                "description": "Emitted whenever an `ERC1155Order` is filled.",
+                "description": "",
                 "type": "STRING"
             }
         ]

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderFilled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderFilled.json
@@ -1,0 +1,131 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "enum LibNFTOrder.TradeDirection",
+                    "name": "direction",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20TokenV06",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20FillAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC1155Token",
+                    "name": "erc1155Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc1155TokenId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "erc1155FillAmount",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "matcher",
+                    "type": "address"
+                }
+            ],
+            "name": "ERC1155OrderFilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v4_0_event_ERC1155OrderFilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "direction",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20FillAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenId",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155FillAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "matcher",
+                "description": "Emitted whenever an `ERC1155Order` is filled.",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderFilled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC1155OrderFilled.json
@@ -78,52 +78,52 @@
         "schema": [
             {
                 "name": "direction",
-                "description": "",
+                "description": "Whether the order is selling or buying the ERC1155 token.",
                 "type": "STRING"
             },
             {
                 "name": "maker",
-                "description": "",
+                "description": "The maker of the order.",
                 "type": "STRING"
             },
             {
                 "name": "taker",
-                "description": "",
+                "description": "The taker of the order.",
                 "type": "STRING"
             },
             {
                 "name": "nonce",
-                "description": "",
+                "description": "The unique maker nonce in the order.",
                 "type": "STRING"
             },
             {
                 "name": "erc20Token",
-                "description": "",
+                "description": "The address of the ERC20 token.",
                 "type": "STRING"
             },
             {
                 "name": "erc20FillAmount",
-                "description": "",
+                "description": "The amount of ERC20 token filled.",
                 "type": "STRING"
             },
             {
                 "name": "erc1155Token",
-                "description": "",
+                "description": "The address of the ERC1155 token.",
                 "type": "STRING"
             },
             {
                 "name": "erc1155TokenId",
-                "description": "",
+                "description": "The ID of the ERC1155 asset.",
                 "type": "STRING"
             },
             {
                 "name": "erc1155FillAmount",
-                "description": "",
+                "description": "The amount of ERC1155 asset filled.",
                 "type": "STRING"
             },
             {
                 "name": "matcher",
-                "description": "",
+                "description": "Currently unused.",
                 "type": "STRING"
             }
         ]

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderCancelled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderCancelled.json
@@ -30,12 +30,12 @@
         "schema": [
             {
                 "name": "maker",
-                "description": "",
+                "description": "The maker of the order.",
                 "type": "STRING"
             },
             {
                 "name": "nonce",
-                "description": "",
+                "description": "The nonce of the order that was cancelled.",
                 "type": "STRING"
             }
         ]

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderCancelled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderCancelled.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC721OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v4_0_event_ERC721OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "Emitted whenever an `ERC721Order` is canceled.",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderCancelled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderCancelled.json
@@ -26,7 +26,7 @@
     "table": {
         "dataset_name": "zeroex",
         "table_name": "Exchange_v4_0_event_ERC721OrderCancelled",
-        "table_description": "",
+        "table_description": "Emitted whenever an `ERC721Order` is canceled.",
         "schema": [
             {
                 "name": "maker",
@@ -35,7 +35,7 @@
             },
             {
                 "name": "nonce",
-                "description": "Emitted whenever an `ERC721Order` is canceled.",
+                "description": "",
                 "type": "STRING"
             }
         ]

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderFilled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderFilled.json
@@ -1,0 +1,120 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "enum LibNFTOrder.TradeDirection",
+                    "name": "direction",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20TokenV06",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20TokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC721Token",
+                    "name": "erc721Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc721TokenId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "matcher",
+                    "type": "address"
+                }
+            ],
+            "name": "ERC721OrderFilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "zeroex",
+        "table_name": "Exchange_v4_0_event_ERC721OrderFilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "direction",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20TokenAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc721Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc721TokenId",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "matcher",
+                "description": "Emitted whenever an `ERC721Order` is filled.",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderFilled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderFilled.json
@@ -68,7 +68,7 @@
     "table": {
         "dataset_name": "zeroex",
         "table_name": "Exchange_v4_0_event_ERC721OrderFilled",
-        "table_description": "",
+        "table_description": "Emitted whenever an `ERC721Order` is filled.",
         "schema": [
             {
                 "name": "direction",
@@ -112,7 +112,7 @@
             },
             {
                 "name": "matcher",
-                "description": "Emitted whenever an `ERC721Order` is filled.",
+                "description": "",
                 "type": "STRING"
             }
         ]

--- a/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderFilled.json
+++ b/dags/resources/stages/parse/table_definitions/zeroex/Exchange_v4_0_event_ERC721OrderFilled.json
@@ -72,47 +72,47 @@
         "schema": [
             {
                 "name": "direction",
-                "description": "",
+                "description": "Whether the order is selling or buying the ERC721 token.",
                 "type": "STRING"
             },
             {
                 "name": "maker",
-                "description": "",
+                "description": "The maker of the order",
                 "type": "STRING"
             },
             {
                 "name": "taker",
-                "description": "",
+                "description": "The taker of the order",
                 "type": "STRING"
             },
             {
                 "name": "nonce",
-                "description": "",
+                "description": "The unique maker nonce in the order.",
                 "type": "STRING"
             },
             {
                 "name": "erc20Token",
-                "description": "",
+                "description": "The address of the ERC20 token.",
                 "type": "STRING"
             },
             {
                 "name": "erc20TokenAmount",
-                "description": "",
+                "description": "The amount of ERC20 token to sell or buy.",
                 "type": "STRING"
             },
             {
                 "name": "erc721Token",
-                "description": "",
+                "description": "The address of the ERC721 token.",
                 "type": "STRING"
             },
             {
                 "name": "erc721TokenId",
-                "description": "",
+                "description": "The ID of the ERC721 asset.",
                 "type": "STRING"
             },
             {
                 "name": "matcher",
-                "description": "",
+                "description": "If this order was matched with another using `matchERC721Orders()`, this will be the address of the caller. If not, this will be `address(0)`.",
                 "type": "STRING"
             }
         ]


### PR DESCRIPTION
Add ERC721 and ERC1155 Order Filled events for the 0x Exchange. Coinbase is using 0x for their NFT marketplace.