### PR TITLE
add Benqi Comptroller

### DIFF
--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_ActionPaused.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_ActionPaused.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -49,6 +49,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_ActionPaused"
+        "table_name": "Comptroller_event_ActionPaused"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_BorrowRewardSpeedUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_BorrowRewardSpeedUpdated.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -49,6 +49,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_BorrowRewardSpeedUpdated"
+        "table_name": "Comptroller_event_BorrowRewardSpeedUpdated"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_ContributorQiSpeedUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_ContributorQiSpeedUpdated.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_ContributorQiSpeedUpdated"
+        "table_name": "Comptroller_event_ContributorQiSpeedUpdated"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_DistributedBorrowerReward.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_DistributedBorrowerReward.json
@@ -42,7 +42,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -71,6 +71,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_DistributedBorrowerReward"
+        "table_name": "Comptroller_event_DistributedBorrowerReward"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_DistributedSupplierReward.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_DistributedSupplierReward.json
@@ -42,7 +42,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -71,6 +71,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_DistributedSupplierReward"
+        "table_name": "Comptroller_event_DistributedSupplierReward"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_Failure.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_Failure.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -49,6 +49,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_Failure"
+        "table_name": "Comptroller_event_Failure"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_MarketEntered.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_MarketEntered.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_MarketEntered"
+        "table_name": "Comptroller_event_MarketEntered"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_MarketExited.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_MarketExited.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_MarketExited"
+        "table_name": "Comptroller_event_MarketExited"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_MarketListed.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_MarketListed.json
@@ -18,7 +18,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -27,6 +27,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_MarketListed"
+        "table_name": "Comptroller_event_MarketListed"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewBorrowCap.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewBorrowCap.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewBorrowCap"
+        "table_name": "Comptroller_event_NewBorrowCap"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewBorrowCapGuardian.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewBorrowCapGuardian.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewBorrowCapGuardian"
+        "table_name": "Comptroller_event_NewBorrowCapGuardian"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewCloseFactor.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewCloseFactor.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewCloseFactor"
+        "table_name": "Comptroller_event_NewCloseFactor"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewCollateralFactor.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewCollateralFactor.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -49,6 +49,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewCollateralFactor"
+        "table_name": "Comptroller_event_NewCollateralFactor"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewLiquidationIncentive.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewLiquidationIncentive.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewLiquidationIncentive"
+        "table_name": "Comptroller_event_NewLiquidationIncentive"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewPauseGuardian.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewPauseGuardian.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewPauseGuardian"
+        "table_name": "Comptroller_event_NewPauseGuardian"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewPriceOracle.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_NewPriceOracle.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_NewPriceOracle"
+        "table_name": "Comptroller_event_NewPriceOracle"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_QiGranted.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_QiGranted.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_QiGranted"
+        "table_name": "Comptroller_event_QiGranted"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_SupplyRewardSpeedUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/benqi/Comptroller_event_SupplyRewardSpeedUpdated.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "avalanche_benqi",
         "schema": [
             {
                 "description": "",
@@ -49,6 +49,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_SupplyRewardSpeedUpdated"
+        "table_name": "Comptroller_event_SupplyRewardSpeedUpdated"
     }
 }


### PR DESCRIPTION
Adds all 18 events from the Benqi Comptroller to blockchain-etl.

Generated via https://nansen-contract-parser-prod.web.app/ on address `0xd8E426C61b0FBBda06e9F603263ABea09d717dBD` on Avalanche chain.