### PR TITLE
simplify parse dag

### DIFF
--- a/dags/ethereum_parse_dag.py
+++ b/dags/ethereum_parse_dag.py
@@ -8,25 +8,37 @@ from ethereumetl_airflow.build_parse_dag import build_parse_dag
 from ethereumetl_airflow.variables import read_parse_dag_vars
 
 DAGS_FOLDER = os.environ.get('DAGS_FOLDER', '/home/airflow/gcs/dags')
-table_definitions_folder = os.path.join(DAGS_FOLDER, 'resources/stages/parse/table_definitions/*')
+table_definitions_folder = os.path.join(DAGS_FOLDER, 'resources/stages/parse/table_definitions_bitski/*')
 
-logging.basicConfig()
-logging.getLogger().setLevel(logging.DEBUG)
+# todo: troubleshoot dynamic dags in aws airflow
 
-var_prefix = 'ethereum_'
+# logging.basicConfig()
+# logging.getLogger().setLevel(logging.DEBUG)
 
-for folder in glob(table_definitions_folder):
-    dataset = folder.split('/')[-1]
+# var_prefix = 'ethereum_'
 
-    dag_id = f'ethereum_parse_{dataset}_dag'
-    logging.info(folder)
-    logging.info(dataset)
-    globals()[dag_id] = build_parse_dag(
-        dag_id=dag_id,
-        dataset_folder=folder,
-        **read_parse_dag_vars(
-            var_prefix=var_prefix,
-            dataset=dataset,
-            schedule_interval='0 14 * * *'
-        )
+# for folder in glob(table_definitions_folder):
+#     dataset = folder.split('/')[-1]
+
+#     dag_id = f'ethereum_parse_{dataset}_dag'
+#     logging.info(folder)
+#     logging.info(dataset)
+#     globals()[dag_id] = build_parse_dag(
+#         dag_id=dag_id,
+#         dataset_folder=folder,
+#         **read_parse_dag_vars(
+#             var_prefix=var_prefix,
+#             dataset=dataset,
+#             schedule_interval='0 14 * * *'
+#         )
+#     )
+
+DAG = build_parse_dag(
+    dag_id='ethereum_parse_opensea_dag',
+    dataset_folder='resources/stages/parse/table_definitions_bitski/opensea',
+    **read_parse_dag_vars(
+        var_prefix='ethereum_',
+        dataset='opensea',
+        schedule_interval='0 14 * * *'
     )
+)


### PR DESCRIPTION
Seems like the `ethereum_parse_dag` is not working as expected. Try simplifying the dag by removing dynamic dag generation which modifies the python globals table and use a static dag_id.

<img width="1090" alt="Screen Shot 2022-06-15 at 1 35 07 PM" src="https://user-images.githubusercontent.com/63827524/173922146-5c57cd48-81f5-4b76-846c-1e94e4b4ec96.png">
 
`ethereum_parse_dag` enabled us to easily create structured tables from contract specific event logs