### PR TITLE
Synthetix SNX token and Synth event table definitions

### DIFF
--- a/dags/resources/stages/parse/table_definitions/synthetix/Synth_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/Synth_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x57ab1ec28d129707052df4df418d58a2d46d5f51', '0xd71ecff9342a5ced620049e616c5035f1db98620', '0xf6b1c627e95bfc3c1b4c9b825a032ff0fbf3e07d', '0xf48e200eaf9906362bb1442fca31e0835773b8b4', '0x97fe22e7341a0cd8db6f6c021a24dc8f4dad855f', '0x0f83287ff768d1c1e17a42f44d644d7f22e8ee1d', '0x269895a3df4d73b077fc823dd6da1b95f72aaf9b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6', '0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb', '0xbbc455cb4f1b9e4bfc4b73970d360c8f032efee6', '0xd2df355c19471c8bd7d8a3aa27ff4e26a21b4076', '0xe36e2d3c7c34281fa3bc737950a68571736880a1', '0x1715ac0743102bf5cd58efbb6cf2dc2685d967b6', '0x104edf1da359506548bfc7c25ba1e28c16a70235'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synth_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/Synth_event_OwnerChanged.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/Synth_event_OwnerChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerChanged",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x57ab1ec28d129707052df4df418d58a2d46d5f51', '0xd71ecff9342a5ced620049e616c5035f1db98620', '0xf6b1c627e95bfc3c1b4c9b825a032ff0fbf3e07d', '0xf48e200eaf9906362bb1442fca31e0835773b8b4', '0x97fe22e7341a0cd8db6f6c021a24dc8f4dad855f', '0x0f83287ff768d1c1e17a42f44d644d7f22e8ee1d', '0x269895a3df4d73b077fc823dd6da1b95f72aaf9b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6', '0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb', '0xbbc455cb4f1b9e4bfc4b73970d360c8f032efee6', '0xd2df355c19471c8bd7d8a3aa27ff4e26a21b4076', '0xe36e2d3c7c34281fa3bc737950a68571736880a1', '0x1715ac0743102bf5cd58efbb6cf2dc2685d967b6', '0x104edf1da359506548bfc7c25ba1e28c16a70235'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synth_event_OwnerChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/Synth_event_OwnerNominated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/Synth_event_OwnerNominated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerNominated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x57ab1ec28d129707052df4df418d58a2d46d5f51', '0xd71ecff9342a5ced620049e616c5035f1db98620', '0xf6b1c627e95bfc3c1b4c9b825a032ff0fbf3e07d', '0xf48e200eaf9906362bb1442fca31e0835773b8b4', '0x97fe22e7341a0cd8db6f6c021a24dc8f4dad855f', '0x0f83287ff768d1c1e17a42f44d644d7f22e8ee1d', '0x269895a3df4d73b077fc823dd6da1b95f72aaf9b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6', '0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb', '0xbbc455cb4f1b9e4bfc4b73970d360c8f032efee6', '0xd2df355c19471c8bd7d8a3aa27ff4e26a21b4076', '0xe36e2d3c7c34281fa3bc737950a68571736880a1', '0x1715ac0743102bf5cd58efbb6cf2dc2685d967b6', '0x104edf1da359506548bfc7c25ba1e28c16a70235'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synth_event_OwnerNominated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/Synth_event_TargetUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/Synth_event_TargetUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract Proxyable",
+                    "name": "newTarget",
+                    "type": "address"
+                }
+            ],
+            "name": "TargetUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x57ab1ec28d129707052df4df418d58a2d46d5f51', '0xd71ecff9342a5ced620049e616c5035f1db98620', '0xf6b1c627e95bfc3c1b4c9b825a032ff0fbf3e07d', '0xf48e200eaf9906362bb1442fca31e0835773b8b4', '0x97fe22e7341a0cd8db6f6c021a24dc8f4dad855f', '0x0f83287ff768d1c1e17a42f44d644d7f22e8ee1d', '0x269895a3df4d73b077fc823dd6da1b95f72aaf9b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6', '0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb', '0xbbc455cb4f1b9e4bfc4b73970d360c8f032efee6', '0xd2df355c19471c8bd7d8a3aa27ff4e26a21b4076', '0xe36e2d3c7c34281fa3bc737950a68571736880a1', '0x1715ac0743102bf5cd58efbb6cf2dc2685d967b6', '0x104edf1da359506548bfc7c25ba1e28c16a70235'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "newTarget",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synth_event_TargetUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/Synth_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/Synth_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x57ab1ec28d129707052df4df418d58a2d46d5f51', '0xd71ecff9342a5ced620049e616c5035f1db98620', '0xf6b1c627e95bfc3c1b4c9b825a032ff0fbf3e07d', '0xf48e200eaf9906362bb1442fca31e0835773b8b4', '0x97fe22e7341a0cd8db6f6c021a24dc8f4dad855f', '0x0f83287ff768d1c1e17a42f44d644d7f22e8ee1d', '0x269895a3df4d73b077fc823dd6da1b95f72aaf9b', '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6', '0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb', '0xbbc455cb4f1b9e4bfc4b73970d360c8f032efee6', '0xd2df355c19471c8bd7d8a3aa27ff4e26a21b4076', '0xe36e2d3c7c34281fa3bc737950a68571736880a1', '0x1715ac0743102bf5cd58efbb6cf2dc2685d967b6', '0x104edf1da359506548bfc7c25ba1e28c16a70235'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synth_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/Synthetix_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/Synthetix_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synthetix_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/Synthetix_event_OwnerChanged.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/Synthetix_event_OwnerChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerChanged",
+            "type": "event"
+        },
+        "contract_address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synthetix_event_OwnerChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/Synthetix_event_OwnerNominated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/Synthetix_event_OwnerNominated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerNominated",
+            "type": "event"
+        },
+        "contract_address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synthetix_event_OwnerNominated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/Synthetix_event_TargetUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/Synthetix_event_TargetUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract Proxyable",
+                    "name": "newTarget",
+                    "type": "address"
+                }
+            ],
+            "name": "TargetUpdated",
+            "type": "event"
+        },
+        "contract_address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "newTarget",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synthetix_event_TargetUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/synthetix/Synthetix_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/synthetix/Synthetix_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "synthetix",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Synthetix_event_Transfer"
+    }
+}


### PR DESCRIPTION
## What?
Add support for contract events from the Synthetix contract (SNX token) and Synth contracts (sUSD, sEUR, sJPY, sAUD, sGPB, sCHF, sKRW, sBTC, sETH, sLINK, sAAVE, sADA, sDOT, sETHBTC).

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions, and grouped together the Synths. Contract addresses are from https://docs.synthetix.io/addresses/#mainnet. 

## Related PRs (optional)
I opened a similar PR for Synthetix on Optimism here: https://github.com/nansen-ai/evmchain-etl-table-definitions/pull/71