### PR TITLE
Add extra_streaming_tables_have_latest.sql verification

### DIFF
--- a/dags/ethereumetl_airflow/variables.py
+++ b/dags/ethereumetl_airflow/variables.py
@@ -119,6 +119,11 @@ def read_verify_streaming_dag_vars(var_prefix, **kwargs):
         'destination_dataset_project_id': read_var('destination_dataset_project_id', var_prefix, True, **kwargs),
         'parse_destination_dataset_project_id': read_var('parse_destination_dataset_project_id', var_prefix, True, **kwargs),
         'verify_partitioned_tables': parse_bool(read_var('verify_partitioned_tables', var_prefix, False, **kwargs), default=False),
+        # Comma separated list of fully qualified BigQuery table names e.g. myproject.streamers.blocks1,myproject.streamers.blocks2
+        # Each table must have a column data containing a JSON object with field timestamp containing unix seconds
+        # Used in combination with https://cloud.google.com/blog/products/data-analytics/pub-sub-launches-direct-path-to-bigquery-for-streaming-analytics
+        # to verify lag of streaming jobs that output to Pub/Sub
+        'extra_streaming_tables': read_var('extra_streaming_tables', var_prefix, False, **kwargs),
         'notification_emails': read_var('notification_emails', None, False, **kwargs),
     }
 

--- a/dags/resources/stages/verify_streaming/sqls/extra_streaming_tables_have_latest.sql
+++ b/dags/resources/stages/verify_streaming/sqls/extra_streaming_tables_have_latest.sql
@@ -1,0 +1,9 @@
+select if(
+(
+select timestamp_diff(
+  current_timestamp(),
+  (select max(timestamp_seconds(cast(json_extract(data, '$.timestamp') AS INTEGER)))
+  from `{{params.streaming_table}}`),
+  MINUTE)
+) < {{params.max_lag_in_minutes}}, 1,
+cast((select 'Streaming table {{params.streaming_table}} is lagging by more than {{params.max_lag_in_minutes}} minutes') as INT64))


### PR DESCRIPTION
## What?
Add extra_streaming_tables_have_latest.sql verification

## How? 

Added a new variable `extra_streaming_tables`- comma separated list of fully qualified BigQuery table names e.g. `myproject.streamers.blocks1,myproject.streamers.blocks2`. Each table must have a column data containing a JSON object with field timestamp containing unix seconds. Used in combination with https://cloud.google.com/blog/products/data-analytics/pub-sub-launches-direct-path-to-bigquery-for-streaming-analytics to verify lag of streaming jobs that output to Pub/Sub
