### PR TITLE
Disable trace verification tasks until Erigon issue is fixed 

### DIFF
--- a/dags/ethereumetl_airflow/build_load_dag.py
+++ b/dags/ethereumetl_airflow/build_load_dag.py
@@ -332,9 +332,9 @@ def build_load_dag(
         verify_transactions_have_latest_task,
         verify_logs_have_latest_task,
         verify_token_transfers_have_latest_task,
-        verify_traces_blocks_count_task,
-        verify_traces_transactions_count_task,
-        verify_traces_contracts_count_task,
+        # verify_traces_blocks_count_task,
+        # verify_traces_transactions_count_task,
+        # verify_traces_contracts_count_task,
         enrich_tokens_task,
         calculate_balances_task,
     ])


### PR DESCRIPTION
## What?
Disable trace verification tasks

## Why?

For some blocks tracing currently fails, see https://github.com/blockchain-etl/ethereum-etl/pull/392

