### PR TITLE
Fix traces_blocks_count verification post-merge

### DIFF
--- a/dags/ethereumetl_airflow/build_load_dag.py
+++ b/dags/ethereumetl_airflow/build_load_dag.py
@@ -332,9 +332,9 @@ def build_load_dag(
         verify_transactions_have_latest_task,
         verify_logs_have_latest_task,
         verify_token_transfers_have_latest_task,
-        # verify_traces_blocks_count_task,
-        # verify_traces_transactions_count_task,
-        # verify_traces_contracts_count_task,
+        verify_traces_blocks_count_task,
+        verify_traces_transactions_count_task,
+        verify_traces_contracts_count_task,
         enrich_tokens_task,
         calculate_balances_task,
     ])

--- a/dags/resources/stages/verify/sqls/traces_blocks_count.sql
+++ b/dags/resources/stages/verify/sqls/traces_blocks_count.sql
@@ -9,5 +9,6 @@ where trace_type = 'reward' and reward_type = 'block'
 select count(*)
 from `{{params.destination_dataset_project_id}}.{{params.dataset_name}}.blocks`
 where date(timestamp) <= '{{ds}}'
+    and number <= 15537393 -- The Merge block number
 ) - 1, 1,
 cast((select 'Total number of unique blocks in traces is not equal to block count minus 1 on {{ds}}') as int64))


### PR DESCRIPTION
## What?
Fix traces_blocks_count verification post-merge

## Why?

There is no block rewards post-merge. It's taken into account in traces_blocks_count.sql