### PR TITLE
Add support for Aura Finance events and calls

### DIFF
--- a/dags/resources/stages/parse/table_definitions/aura/AuraBalInitialStaking_event_RewardAdded.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraBalInitialStaking_event_RewardAdded.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "reward",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RewardAdded",
+            "type": "event"
+        },
+        "contract_address": "0xc47162863a12227e5c3b0860715f9cf721651c0c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "reward",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraBalInitialStaking_event_RewardAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraBalInitialStaking_event_RewardPaid.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraBalInitialStaking_event_RewardPaid.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "reward",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "locked",
+                    "type": "bool"
+                }
+            ],
+            "name": "RewardPaid",
+            "type": "event"
+        },
+        "contract_address": "0xc47162863a12227e5c3b0860715f9cf721651c0c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reward",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "locked",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraBalInitialStaking_event_RewardPaid"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraBalInitialStaking_event_Staked.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraBalInitialStaking_event_Staked.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Staked",
+            "type": "event"
+        },
+        "contract_address": "0xc47162863a12227e5c3b0860715f9cf721651c0c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraBalInitialStaking_event_Staked"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraBalInitialStaking_event_Withdrawn.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraBalInitialStaking_event_Withdrawn.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdrawn",
+            "type": "event"
+        },
+        "contract_address": "0xc47162863a12227e5c3b0860715f9cf721651c0c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraBalInitialStaking_event_Withdrawn"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_BlacklistModified.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_BlacklistModified.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "blacklisted",
+                    "type": "bool"
+                }
+            ],
+            "name": "BlacklistModified",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "blacklisted",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraLocker_event_BlacklistModified"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_DelegateChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_DelegateChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "delegator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromDelegate",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toDelegate",
+                    "type": "address"
+                }
+            ],
+            "name": "DelegateChanged",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "delegator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fromDelegate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toDelegate",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraLocker_event_DelegateChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_DelegateCheckpointed.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_DelegateCheckpointed.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "delegate",
+                    "type": "address"
+                }
+            ],
+            "name": "DelegateCheckpointed",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "delegate",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraLocker_event_DelegateCheckpointed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_KickIncentiveSet.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_KickIncentiveSet.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "rate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "delay",
+                    "type": "uint256"
+                }
+            ],
+            "name": "KickIncentiveSet",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "rate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "delay",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraLocker_event_KickIncentiveSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_KickReward.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_KickReward.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_kicked",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_reward",
+                    "type": "uint256"
+                }
+            ],
+            "name": "KickReward",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "_user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_kicked",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_reward",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraLocker_event_KickReward"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraLocker_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_Recovered.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_Recovered.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "_token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Recovered",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "_token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraLocker_event_Recovered"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_RewardAdded.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_RewardAdded.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_reward",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RewardAdded",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "_token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_reward",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraLocker_event_RewardAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_RewardPaid.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_RewardPaid.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_rewardsToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_reward",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RewardPaid",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "_user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_rewardsToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_reward",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraLocker_event_RewardPaid"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_Shutdown.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_Shutdown.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Shutdown",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [],
+        "table_description": "",
+        "table_name": "AuraLocker_event_Shutdown"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_Staked.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_Staked.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_paidAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_lockedAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Staked",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "_user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_paidAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_lockedAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraLocker_event_Staked"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_Withdrawn.json
+++ b/dags/resources/stages/parse/table_definitions/aura/AuraLocker_event_Withdrawn.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "_relocked",
+                    "type": "bool"
+                }
+            ],
+            "name": "Withdrawn",
+            "type": "event"
+        },
+        "contract_address": "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "_user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_relocked",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AuraLocker_event_Withdrawn"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/Booster_event_Deposited.json
+++ b/dags/resources/stages/parse/table_definitions/aura/Booster_event_Deposited.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "poolid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposited",
+            "type": "event"
+        },
+        "contract_address": "0x7818a1da7bd1e64c199029e86ba244a9798eee10",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "poolid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Booster_event_Deposited"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/Booster_event_FactoriesUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aura/Booster_event_FactoriesUpdated.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "rewardFactory",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "stashFactory",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "tokenFactory",
+                    "type": "address"
+                }
+            ],
+            "name": "FactoriesUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x7818a1da7bd1e64c199029e86ba244a9798eee10",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "rewardFactory",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stashFactory",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenFactory",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Booster_event_FactoriesUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/Booster_event_FeeInfoChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aura/Booster_event_FeeInfoChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "feeDistro",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "active",
+                    "type": "bool"
+                }
+            ],
+            "name": "FeeInfoChanged",
+            "type": "event"
+        },
+        "contract_address": "0x7818a1da7bd1e64c199029e86ba244a9798eee10",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "feeDistro",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "active",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Booster_event_FeeInfoChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/Booster_event_FeeInfoUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aura/Booster_event_FeeInfoUpdated.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "feeDistro",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "lockFees",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "feeToken",
+                    "type": "address"
+                }
+            ],
+            "name": "FeeInfoUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x7818a1da7bd1e64c199029e86ba244a9798eee10",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "feeDistro",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "lockFees",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeToken",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Booster_event_FeeInfoUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/Booster_event_FeeManagerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aura/Booster_event_FeeManagerUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newFeeManager",
+                    "type": "address"
+                }
+            ],
+            "name": "FeeManagerUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x7818a1da7bd1e64c199029e86ba244a9798eee10",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "newFeeManager",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Booster_event_FeeManagerUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/Booster_event_FeesUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aura/Booster_event_FeesUpdated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "lockIncentive",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "stakerIncentive",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "earmarkIncentive",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "platformFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FeesUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x7818a1da7bd1e64c199029e86ba244a9798eee10",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "lockIncentive",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stakerIncentive",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "earmarkIncentive",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "platformFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Booster_event_FeesUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/Booster_event_PoolAdded.json
+++ b/dags/resources/stages/parse/table_definitions/aura/Booster_event_PoolAdded.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "lpToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "gauge",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "rewardPool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "stash",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "pid",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PoolAdded",
+            "type": "event"
+        },
+        "contract_address": "0x7818a1da7bd1e64c199029e86ba244a9798eee10",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "lpToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "gauge",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "rewardPool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pid",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Booster_event_PoolAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/Booster_event_PoolManagerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aura/Booster_event_PoolManagerUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPoolManager",
+                    "type": "address"
+                }
+            ],
+            "name": "PoolManagerUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x7818a1da7bd1e64c199029e86ba244a9798eee10",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "newPoolManager",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Booster_event_PoolManagerUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/Booster_event_RewardContractsUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aura/Booster_event_RewardContractsUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "lockRewards",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "stakerRewards",
+                    "type": "address"
+                }
+            ],
+            "name": "RewardContractsUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x7818a1da7bd1e64c199029e86ba244a9798eee10",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "lockRewards",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stakerRewards",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Booster_event_RewardContractsUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/Booster_event_Withdrawn.json
+++ b/dags/resources/stages/parse/table_definitions/aura/Booster_event_Withdrawn.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "poolid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdrawn",
+            "type": "event"
+        },
+        "contract_address": "0x7818a1da7bd1e64c199029e86ba244a9798eee10",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "poolid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Booster_event_Withdrawn"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/auraBALDepositorWrapper_call_deposit.json
+++ b/dags/resources/stages/parse/table_definitions/aura/auraBALDepositorWrapper_call_deposit.json
@@ -1,0 +1,62 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_minOut",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "_lock",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_stakeAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "deposit",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x68655ad9852a99c87c0934c7290bb62cfa5d4123",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_minOut",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_lock",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_stakeAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "auraBALDepositorWrapper_call_deposit"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/auraBALDepositorWrapper_call_depositor.json
+++ b/dags/resources/stages/parse/table_definitions/aura/auraBALDepositorWrapper_call_depositor.json
@@ -1,0 +1,26 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [],
+            "name": "crvDeposit",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        "contract_address": "0x68655ad9852a99c87c0934c7290bb62cfa5d4123",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [],
+        "table_description": "",
+        "table_name": "auraBALDepositorWrapper_call_depositor"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/auraBALDepositor_call_deposit.json
+++ b/dags/resources/stages/parse/table_definitions/aura/auraBALDepositor_call_deposit.json
@@ -1,0 +1,42 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "_lock",
+                    "type": "bool"
+                }
+            ],
+            "name": "deposit",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0xead792b55340aa20181a80d6a16db6a0ecd1b827",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_lock",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "auraBALDepositor_call_deposit"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/auraBALDepositor_call_depositAll.json
+++ b/dags/resources/stages/parse/table_definitions/aura/auraBALDepositor_call_depositAll.json
@@ -1,0 +1,42 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "bool",
+                    "name": "_lock",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_stakeAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "depositAll",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0xead792b55340aa20181a80d6a16db6a0ecd1b827",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "_lock",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_stakeAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "auraBALDepositor_call_depositAll"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/auraBALRewardPool_event_RewardAdded.json
+++ b/dags/resources/stages/parse/table_definitions/aura/auraBALRewardPool_event_RewardAdded.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "reward",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RewardAdded",
+            "type": "event"
+        },
+        "contract_address": "0x5e5ea2048475854a5702f5b8468a51ba1296efcc",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "reward",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "auraBALRewardPool_event_RewardAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/auraBALRewardPool_event_RewardPaid.json
+++ b/dags/resources/stages/parse/table_definitions/aura/auraBALRewardPool_event_RewardPaid.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "reward",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RewardPaid",
+            "type": "event"
+        },
+        "contract_address": "0x5e5ea2048475854a5702f5b8468a51ba1296efcc",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reward",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "auraBALRewardPool_event_RewardPaid"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/auraBALRewardPool_event_Staked.json
+++ b/dags/resources/stages/parse/table_definitions/aura/auraBALRewardPool_event_Staked.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Staked",
+            "type": "event"
+        },
+        "contract_address": "0x5e5ea2048475854a5702f5b8468a51ba1296efcc",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "auraBALRewardPool_event_Staked"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aura/auraBALRewardPool_event_Withdrawn.json
+++ b/dags/resources/stages/parse/table_definitions/aura/auraBALRewardPool_event_Withdrawn.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdrawn",
+            "type": "event"
+        },
+        "contract_address": "0x5e5ea2048475854a5702f5b8468a51ba1296efcc",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aura",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "auraBALRewardPool_event_Withdrawn"
+    }
+}


### PR DESCRIPTION
## What?
Add support for Aura Finance events and calls.

## How? 
I used [abi-parser](https://contract-parser.d5.ai/) to build the table definitions.

## Related PRs (optional)
None.
