### PR TITLE
Set depends_on_past to False for parse DAG

### DIFF
--- a/dags/ethereumetl_airflow/build_parse_dag.py
+++ b/dags/ethereumetl_airflow/build_parse_dag.py
@@ -51,7 +51,7 @@ def build_parse_dag(
         PARTITION_DAG_ID = 'ethereum_partition_dag'
 
     default_dag_args = {
-        'depends_on_past': True,
+        'depends_on_past': False,
         'start_date': parse_start_date,
         'email_on_failure': True,
         'email_on_retry': False,


### PR DESCRIPTION
## What

Set depends_on_past to False for parse DAG

## Why

It makes it necessary to manually set DAG runs to true when new tasks are added, while not adding any value during the normal execution of DAGs


