### PR TITLE
Mitigate issue with parsing of tuples in sudoswap trace definition

### DIFF
--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactory_call_createPairERC20.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactory_call_createPairERC20.json
@@ -80,60 +80,8 @@
         "schema": [
             {
                 "description": "",
-                "fields": [
-                    {
-                        "description": "",
-                        "name": "token",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "nft",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "bondingCurve",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "assetRecipient",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "poolType",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "delta",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "fee",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "spotPrice",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "initialNFTIDs",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "initialTokenBalance",
-                        "type": "STRING"
-                    }
-                ],
                 "name": "params",
-                "type": "RECORD"
+                "type": "STRING"
             }
         ],
         "table_description": "",


### PR DESCRIPTION
We currently do not parse nested fields correctly for traces, turning them into nulls in BigQuery. To mitigate we cast them to `STRING` instead.

Related PR to apply this mitigation by default for now in abi-parser: https://github.com/nansen-ai/abi-parser/pull/70.

cc @ben-xu001 