### PR TITLE
Quick fix for `load_dag` task `traces_blocks_count`

### DIFF
--- a/dags/resources/stages/verify/sqls/traces_blocks_count.sql
+++ b/dags/resources/stages/verify/sqls/traces_blocks_count.sql
@@ -4,6 +4,7 @@ select count(distinct(block_number))
 from `{{params.destination_dataset_project_id}}.{{params.dataset_name}}.traces`
 where trace_type = 'reward' and reward_type = 'block'
     and date(block_timestamp) <= '{{ds}}'
+    and value > 0
 ) =
 (
 select count(*)


### PR DESCRIPTION
## What?
- Quick fix to unblock the load_dag

## Why?
Production `ethereum_load_dag` failing  on task `verify_traces_blocks_count`
[Airflow Log](https://8d2acbaf88c940708d5d71686aef80d2-dot-us-central1.composer.googleusercontent.com/log?dag_id=ethereum_load_dag&task_id=verify_traces_blocks_count&execution_date=2022-10-23T12%3A30%3A00%2B00%3A00)

## How?
- As a quick fix, exclude traces with rewards whose value is 0
- Longer term, we need to look at whether the node should be returning block rewards with value 0
- If so, we may need to backfill the export
- But this is just a quick fix to unblock the production `load_dag`
