### PR TITLE
Add Compound v3 events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/compound_v3/CometRewards_event_GovernorTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/CometRewards_event_GovernorTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldGovernor",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newGovernor",
+                    "type": "address"
+                }
+            ],
+            "name": "GovernorTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x1b0e765f6224c21223aea2af16c1c46e38885a40",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldGovernor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newGovernor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "CometRewards_event_GovernorTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/CometRewards_event_GovernorTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/CometRewards_event_GovernorTransferred.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/CometRewards_event_RewardClaimed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/CometRewards_event_RewardClaimed.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RewardClaimed",
+            "type": "event"
+        },
+        "contract_address": "0x1b0e765f6224c21223aea2af16c1c46e38885a40",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "src",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "CometRewards_event_RewardClaimed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/CometRewards_event_RewardClaimed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/CometRewards_event_RewardClaimed.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_AbsorbCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_AbsorbCollateral.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "absorber",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collateralAbsorbed",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "usdValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AbsorbCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "absorber",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateralAbsorbed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "usdValue",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comet_event_AbsorbCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_AbsorbCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_AbsorbCollateral.json
@@ -42,7 +42,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_AbsorbDebt.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_AbsorbDebt.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "absorber",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "basePaidOut",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "usdValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AbsorbDebt",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "absorber",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "basePaidOut",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "usdValue",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comet_event_AbsorbDebt"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_AbsorbDebt.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_AbsorbDebt.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_BuyCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_BuyCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "buyer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "baseAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collateralAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BuyCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "buyer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "baseAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateralAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comet_event_BuyCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_BuyCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_BuyCollateral.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_PauseAction.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_PauseAction.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "supplyPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "transferPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "withdrawPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "absorbPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "buyPaused",
+                    "type": "bool"
+                }
+            ],
+            "name": "PauseAction",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "supplyPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "transferPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "withdrawPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "absorbPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "buyPaused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comet_event_PauseAction"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_PauseAction.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_PauseAction.json
@@ -42,7 +42,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Supply.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Supply.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Supply",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dst",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comet_event_Supply"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Supply.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Supply.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_SupplyCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_SupplyCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dst",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comet_event_SupplyCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_SupplyCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_SupplyCollateral.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comet_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Transfer.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_TransferCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_TransferCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TransferCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comet_event_TransferCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_TransferCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_TransferCollateral.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Withdraw.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Withdraw.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdraw",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "src",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comet_event_Withdraw"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Withdraw.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_Withdraw.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_WithdrawCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_WithdrawCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "src",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comet_event_WithdrawCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_WithdrawCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_WithdrawCollateral.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_WithdrawReserves.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_WithdrawReserves.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawReserves",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Comet_event_WithdrawReserves"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_WithdrawReserves.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Comet_event_WithdrawReserves.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_AddAsset.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_AddAsset.json
@@ -1,0 +1,117 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "asset",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "priceFeed",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidateCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidationFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint128",
+                            "name": "supplyCap",
+                            "type": "uint128"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CometConfiguration.AssetConfig",
+                    "name": "assetConfig",
+                    "type": "tuple"
+                }
+            ],
+            "name": "AddAsset",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "asset",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "priceFeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "decimals",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidateCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyCap",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "assetConfig",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_AddAsset"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_AddAsset.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_AddAsset.json
@@ -61,7 +61,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_CometDeployed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_CometDeployed.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newComet",
+                    "type": "address"
+                }
+            ],
+            "name": "CometDeployed",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newComet",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_CometDeployed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_CometDeployed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_CometDeployed.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_GovernorTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_GovernorTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldGovernor",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newGovernor",
+                    "type": "address"
+                }
+            ],
+            "name": "GovernorTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldGovernor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newGovernor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_GovernorTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_GovernorTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_GovernorTransferred.json
@@ -24,7 +24,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseBorrowMin.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseBorrowMin.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "oldBaseBorrowMin",
+                    "type": "uint104"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "newBaseBorrowMin",
+                    "type": "uint104"
+                }
+            ],
+            "name": "SetBaseBorrowMin",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBaseBorrowMin",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBaseBorrowMin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetBaseBorrowMin"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseBorrowMin.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseBorrowMin.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseMinForRewards.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseMinForRewards.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "oldBaseMinForRewards",
+                    "type": "uint104"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "newBaseMinForRewards",
+                    "type": "uint104"
+                }
+            ],
+            "name": "SetBaseMinForRewards",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBaseMinForRewards",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBaseMinForRewards",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetBaseMinForRewards"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseMinForRewards.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseMinForRewards.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTokenPriceFeed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTokenPriceFeed.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldBaseTokenPriceFeed",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newBaseTokenPriceFeed",
+                    "type": "address"
+                }
+            ],
+            "name": "SetBaseTokenPriceFeed",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBaseTokenPriceFeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBaseTokenPriceFeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetBaseTokenPriceFeed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTokenPriceFeed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTokenPriceFeed.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTrackingBorrowSpeed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTrackingBorrowSpeed.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldBaseTrackingBorrowSpeed",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newBaseTrackingBorrowSpeed",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBaseTrackingBorrowSpeed",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBaseTrackingBorrowSpeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBaseTrackingBorrowSpeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetBaseTrackingBorrowSpeed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTrackingBorrowSpeed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTrackingBorrowSpeed.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTrackingSupplySpeed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTrackingSupplySpeed.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldBaseTrackingSupplySpeed",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newBaseTrackingSupplySpeed",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBaseTrackingSupplySpeed",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBaseTrackingSupplySpeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBaseTrackingSupplySpeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetBaseTrackingSupplySpeed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTrackingSupplySpeed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBaseTrackingSupplySpeed.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowKink.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowKink.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldKink",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newKink",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBorrowKink",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldKink",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newKink",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetBorrowKink"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowKink.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowKink.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateBase.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateBase.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRBase",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRBase",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBorrowPerYearInterestRateBase",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRBase",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRBase",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetBorrowPerYearInterestRateBase"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateBase.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateBase.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateSlopeHigh.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateSlopeHigh.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRSlopeHigh",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRSlopeHigh",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBorrowPerYearInterestRateSlopeHigh",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRSlopeHigh",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRSlopeHigh",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetBorrowPerYearInterestRateSlopeHigh"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateSlopeHigh.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateSlopeHigh.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateSlopeLow.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateSlopeLow.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRSlopeLow",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRSlopeLow",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBorrowPerYearInterestRateSlopeLow",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRSlopeLow",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRSlopeLow",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetBorrowPerYearInterestRateSlopeLow"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateSlopeLow.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetBorrowPerYearInterestRateSlopeLow.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetConfiguration.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetConfiguration.json
@@ -318,7 +318,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetConfiguration.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetConfiguration.json
@@ -1,0 +1,556 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "governor",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "pauseGuardian",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "baseToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "baseTokenPriceFeed",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "extensionDelegate",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyKink",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateSlopeLow",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateSlopeHigh",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateBase",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowKink",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateSlopeLow",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateSlopeHigh",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateBase",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "storeFrontPriceFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "trackingIndexScale",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "baseTrackingSupplySpeed",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "baseTrackingBorrowSpeed",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "baseMinForRewards",
+                            "type": "uint104"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "baseBorrowMin",
+                            "type": "uint104"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "targetReserves",
+                            "type": "uint104"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "asset",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "priceFeed",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint8",
+                                    "name": "decimals",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "borrowCollateralFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "liquidateCollateralFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "liquidationFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint128",
+                                    "name": "supplyCap",
+                                    "type": "uint128"
+                                }
+                            ],
+                            "internalType": "struct CometConfiguration.AssetConfig[]",
+                            "name": "assetConfigs",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CometConfiguration.Configuration",
+                    "name": "oldConfiguration",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "governor",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "pauseGuardian",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "baseToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "baseTokenPriceFeed",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "extensionDelegate",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyKink",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateSlopeLow",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateSlopeHigh",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateBase",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowKink",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateSlopeLow",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateSlopeHigh",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateBase",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "storeFrontPriceFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "trackingIndexScale",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "baseTrackingSupplySpeed",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "baseTrackingBorrowSpeed",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "baseMinForRewards",
+                            "type": "uint104"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "baseBorrowMin",
+                            "type": "uint104"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "targetReserves",
+                            "type": "uint104"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "asset",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "priceFeed",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint8",
+                                    "name": "decimals",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "borrowCollateralFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "liquidateCollateralFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "liquidationFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint128",
+                                    "name": "supplyCap",
+                                    "type": "uint128"
+                                }
+                            ],
+                            "internalType": "struct CometConfiguration.AssetConfig[]",
+                            "name": "assetConfigs",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CometConfiguration.Configuration",
+                    "name": "newConfiguration",
+                    "type": "tuple"
+                }
+            ],
+            "name": "SetConfiguration",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "governor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pauseGuardian",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseToken",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTokenPriceFeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "extensionDelegate",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyKink",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateSlopeLow",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateSlopeHigh",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateBase",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowKink",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateSlopeLow",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateSlopeHigh",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateBase",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "storeFrontPriceFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "trackingIndexScale",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTrackingSupplySpeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTrackingBorrowSpeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseMinForRewards",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseBorrowMin",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "targetReserves",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "assetConfigs",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "oldConfiguration",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "governor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pauseGuardian",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseToken",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTokenPriceFeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "extensionDelegate",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyKink",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateSlopeLow",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateSlopeHigh",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateBase",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowKink",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateSlopeLow",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateSlopeHigh",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateBase",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "storeFrontPriceFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "trackingIndexScale",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTrackingSupplySpeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTrackingBorrowSpeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseMinForRewards",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseBorrowMin",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "targetReserves",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "assetConfigs",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "newConfiguration",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetConfiguration"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetExtensionDelegate.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetExtensionDelegate.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldExt",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newExt",
+                    "type": "address"
+                }
+            ],
+            "name": "SetExtensionDelegate",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldExt",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newExt",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetExtensionDelegate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetExtensionDelegate.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetExtensionDelegate.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetFactory.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetFactory.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldFactory",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newFactory",
+                    "type": "address"
+                }
+            ],
+            "name": "SetFactory",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldFactory",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFactory",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetFactory"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetFactory.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetFactory.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetGovernor.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetGovernor.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldGovernor",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newGovernor",
+                    "type": "address"
+                }
+            ],
+            "name": "SetGovernor",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldGovernor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newGovernor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetGovernor"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetGovernor.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetGovernor.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetPauseGuardian.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetPauseGuardian.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldPauseGuardian",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newPauseGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "SetPauseGuardian",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldPauseGuardian",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPauseGuardian",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetPauseGuardian"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetPauseGuardian.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetPauseGuardian.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetStoreFrontPriceFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetStoreFrontPriceFactor.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldStoreFrontPriceFactor",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newStoreFrontPriceFactor",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetStoreFrontPriceFactor",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldStoreFrontPriceFactor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newStoreFrontPriceFactor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetStoreFrontPriceFactor"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetStoreFrontPriceFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetStoreFrontPriceFactor.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyKink.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyKink.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldKink",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newKink",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetSupplyKink",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldKink",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newKink",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetSupplyKink"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyKink.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyKink.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateBase.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateBase.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRBase",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRBase",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetSupplyPerYearInterestRateBase",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRBase",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRBase",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetSupplyPerYearInterestRateBase"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateBase.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateBase.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateSlopeHigh.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateSlopeHigh.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRSlopeHigh",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRSlopeHigh",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetSupplyPerYearInterestRateSlopeHigh",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRSlopeHigh",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRSlopeHigh",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetSupplyPerYearInterestRateSlopeHigh"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateSlopeHigh.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateSlopeHigh.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateSlopeLow.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateSlopeLow.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRSlopeLow",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRSlopeLow",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetSupplyPerYearInterestRateSlopeLow",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRSlopeLow",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRSlopeLow",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetSupplyPerYearInterestRateSlopeLow"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateSlopeLow.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetSupplyPerYearInterestRateSlopeLow.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetTargetReserves.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetTargetReserves.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "oldTargetReserves",
+                    "type": "uint104"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "newTargetReserves",
+                    "type": "uint104"
+                }
+            ],
+            "name": "SetTargetReserves",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldTargetReserves",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTargetReserves",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_SetTargetReserves"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetTargetReserves.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_SetTargetReserves.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAsset.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAsset.json
@@ -1,0 +1,202 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "asset",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "priceFeed",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidateCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidationFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint128",
+                            "name": "supplyCap",
+                            "type": "uint128"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CometConfiguration.AssetConfig",
+                    "name": "oldAssetConfig",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "asset",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "priceFeed",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidateCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidationFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint128",
+                            "name": "supplyCap",
+                            "type": "uint128"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CometConfiguration.AssetConfig",
+                    "name": "newAssetConfig",
+                    "type": "tuple"
+                }
+            ],
+            "name": "UpdateAsset",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "asset",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "priceFeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "decimals",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidateCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyCap",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "oldAssetConfig",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "asset",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "priceFeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "decimals",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidateCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyCap",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "newAssetConfig",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_UpdateAsset"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAsset.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAsset.json
@@ -104,7 +104,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetBorrowCollateralFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetBorrowCollateralFactor.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldBorrowCF",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newBorrowCF",
+                    "type": "uint64"
+                }
+            ],
+            "name": "UpdateAssetBorrowCollateralFactor",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBorrowCF",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowCF",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_UpdateAssetBorrowCollateralFactor"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetBorrowCollateralFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetBorrowCollateralFactor.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetLiquidateCollateralFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetLiquidateCollateralFactor.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldLiquidateCF",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newLiquidateCF",
+                    "type": "uint64"
+                }
+            ],
+            "name": "UpdateAssetLiquidateCollateralFactor",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldLiquidateCF",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newLiquidateCF",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_UpdateAssetLiquidateCollateralFactor"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetLiquidateCollateralFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetLiquidateCollateralFactor.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetLiquidationFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetLiquidationFactor.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetLiquidationFactor.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetLiquidationFactor.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldLiquidationFactor",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newLiquidationFactor",
+                    "type": "uint64"
+                }
+            ],
+            "name": "UpdateAssetLiquidationFactor",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldLiquidationFactor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newLiquidationFactor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_UpdateAssetLiquidationFactor"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetPriceFeed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetPriceFeed.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldPriceFeed",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPriceFeed",
+                    "type": "address"
+                }
+            ],
+            "name": "UpdateAssetPriceFeed",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldPriceFeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPriceFeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_UpdateAssetPriceFeed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetPriceFeed.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetPriceFeed.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetSupplyCap.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetSupplyCap.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldSupplyCap",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newSupplyCap",
+                    "type": "uint128"
+                }
+            ],
+            "name": "UpdateAssetSupplyCap",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldSupplyCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_event_UpdateAssetSupplyCap"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetSupplyCap.json
+++ b/dags/resources/stages/parse/table_definitions/compound_v3/Configurator_event_UpdateAssetSupplyCap.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "",
+        "dataset_name": "compound_v3",
         "schema": [
             {
                 "description": "",


### PR DESCRIPTION
## What?
Add support for Compound III events

## How? 
I used the ABI parser on the contracts here: https://docs.compound.finance/
and also changed the address manually from the implementation address to the proxy

## Related PRs (optional)

## Anything Else?
Wasn't sure if `compound_v3`  is preferred as the dataset name over `compound_iii` but can change it if we want to be more consistent with the docs/naming they use. 
