### PR TITLE
:sparkles: add Bancor V3 events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_FlashLoanCompleted.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_FlashLoanCompleted.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "feeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FlashLoanCompleted",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "feeAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_FlashLoanCompleted"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_FundsMigrated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_FundsMigrated.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "contextId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "provider",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "availableAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "originalAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FundsMigrated",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "contextId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "provider",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "availableAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "originalAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_FundsMigrated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_NetworkFeesWithdrawn.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_NetworkFeesWithdrawn.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NetworkFeesWithdrawn",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "caller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_NetworkFeesWithdrawn"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_Paused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_PoolAdded.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_PoolAdded.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IPoolCollection",
+                    "name": "poolCollection",
+                    "type": "address"
+                }
+            ],
+            "name": "PoolAdded",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "poolCollection",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_PoolAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_PoolCollectionAdded.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_PoolCollectionAdded.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint16",
+                    "name": "poolType",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IPoolCollection",
+                    "name": "poolCollection",
+                    "type": "address"
+                }
+            ],
+            "name": "PoolCollectionAdded",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "poolType",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "poolCollection",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_PoolCollectionAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_PoolCollectionRemoved.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_PoolCollectionRemoved.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint16",
+                    "name": "poolType",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IPoolCollection",
+                    "name": "poolCollection",
+                    "type": "address"
+                }
+            ],
+            "name": "PoolCollectionRemoved",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "poolType",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "poolCollection",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_PoolCollectionRemoved"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_PoolCreated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_PoolCreated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IPoolCollection",
+                    "name": "poolCollection",
+                    "type": "address"
+                }
+            ],
+            "name": "PoolCreated",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "poolCollection",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_PoolCreated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_PoolRemoved.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_PoolRemoved.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IPoolCollection",
+                    "name": "poolCollection",
+                    "type": "address"
+                }
+            ],
+            "name": "PoolRemoved",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "poolCollection",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_PoolRemoved"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_RoleAdminChanged.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_RoleAdminChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "role",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "previousAdminRole",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "newAdminRole",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "RoleAdminChanged",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "role",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "previousAdminRole",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newAdminRole",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_RoleAdminChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_RoleGranted.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_RoleGranted.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "role",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                }
+            ],
+            "name": "RoleGranted",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "role",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_RoleGranted"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_RoleRevoked.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_RoleRevoked.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "role",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                }
+            ],
+            "name": "RoleRevoked",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "role",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_RoleRevoked"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_TokensTraded.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_TokensTraded.json
@@ -1,0 +1,120 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "contextId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "sourceToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "targetToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "sourceAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "targetAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "bntAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "targetFeeAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "bntFeeAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                }
+            ],
+            "name": "TokensTraded",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "contextId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "targetToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sourceAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "targetAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "bntAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "targetFeeAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "bntFeeAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "trader",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_TokensTraded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/BancorNetworkV3_event_Unpaused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0xeef417e1d5cc832e619ae18d2f140de2999dd4fb",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BancorNetworkV3_event_Unpaused"
+    }
+}


### PR DESCRIPTION
## What?
ie: Add support for Bancor V3 contract events 

## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table defenitions and also changed the address manually from the implementation address to the proxy

