### PR TITLE
Parse v2 DAG

### DIFF
--- a/dags/ethereum_parse_v2_dag.py
+++ b/dags/ethereum_parse_v2_dag.py
@@ -1,11 +1,11 @@
 from __future__ import print_function
 
-from glob import glob
 import logging
 import os
+from glob import glob
 
 from ethereum_parse_v2_datasets import PARSE_V2_DATASETS
-from ethereumetl_airflow.build_parse_dag import build_parse_dag
+from ethereumetl_airflow.build_parse_v2_dag import build_parse_v2_dag
 from ethereumetl_airflow.variables import read_parse_dag_vars
 
 DAGS_FOLDER = os.environ.get('DAGS_FOLDER', '/home/airflow/gcs/dags')
@@ -19,13 +19,13 @@ var_prefix = 'ethereum_'
 for folder in glob(table_definitions_folder):
     dataset = folder.split('/')[-1]
 
-    if dataset in PARSE_V2_DATASETS:
+    if dataset not in PARSE_V2_DATASETS:
         continue
 
-    dag_id = f'ethereum_parse_{dataset}_dag'
+    dag_id = f'ethereum_parse_v2_{dataset}_dag'
     logging.info(folder)
     logging.info(dataset)
-    globals()[dag_id] = build_parse_dag(
+    globals()[dag_id] = build_parse_v2_dag(
         dag_id=dag_id,
         dataset_folder=folder,
         **read_parse_dag_vars(

--- a/dags/ethereum_parse_v2_datasets.py
+++ b/dags/ethereum_parse_v2_datasets.py
@@ -1,0 +1,1 @@
+PARSE_V2_DATASETS = {'aelf', 'curve'}

--- a/dags/ethereumetl_airflow/build_parse_v2_dag.py
+++ b/dags/ethereumetl_airflow/build_parse_v2_dag.py
@@ -1,0 +1,216 @@
+from __future__ import print_function
+
+import collections
+import logging
+import os
+from datetime import datetime, timedelta
+
+from airflow import models
+from airflow.operators.bash import BashOperator
+from airflow.operators.python import PythonOperator
+from airflow.sensors.external_task import ExternalTaskSensor
+from google.cloud import bigquery
+
+from ethereumetl_airflow.bigquery_utils import create_view, share_dataset_all_users_read
+from ethereumetl_airflow.common import read_json_file, read_file, get_list_of_files
+from ethereumetl_airflow.parse.parse_dataset_folder_logic import parse_dataset_folder
+from ethereumetl_airflow.parse.parse_logic import create_dataset
+
+logging.basicConfig()
+logging.getLogger().setLevel(logging.DEBUG)
+
+dags_folder = os.environ.get('DAGS_FOLDER', '/home/airflow/gcs/dags')
+
+
+def build_parse_v2_dag(
+        dag_id,
+        dataset_folder,
+        parse_destination_dataset_project_id,
+        notification_emails=None,
+        parse_start_date=datetime(2018, 7, 1),
+        schedule_interval='0 0 * * *',
+        parse_all_partitions=None
+):
+
+    logging.info('parse_all_partitions is {}'.format(parse_all_partitions))
+
+    if parse_all_partitions:
+        dag_id = dag_id + '_FULL'
+
+    if 'ethereum_kovan_parse' in dag_id:
+        SOURCE_PROJECT_ID = 'public-data-finance'
+        SOURCE_DATASET_NAME = 'crypto_ethereum_kovan'
+
+        PARTITION_DAG_ID = 'ethereum_kovan_partition_dag'
+    else:
+        SOURCE_PROJECT_ID = 'bigquery-public-data'
+        SOURCE_DATASET_NAME = 'crypto_ethereum'
+
+        PARTITION_DAG_ID = 'ethereum_partition_dag'
+
+    default_dag_args = {
+        'depends_on_past': False,
+        'start_date': parse_start_date,
+        'email_on_failure': True,
+        'email_on_retry': False,
+        'retries': 5,
+        'retry_delay': timedelta(minutes=5)
+    }
+
+    if notification_emails and len(notification_emails) > 0:
+        default_dag_args['email'] = [email.strip() for email in notification_emails.split(',')]
+
+    dag = models.DAG(
+        dag_id,
+        catchup=False,
+        schedule_interval=schedule_interval,
+        default_args=default_dag_args)
+
+    def create_parse_v2_task():
+
+        def parse_v2_task(ds, **kwargs):
+            validate_definition_files(dataset_folder)
+
+            client = bigquery.Client()
+
+            parse_dataset_folder(
+                bigquery_client=client,
+                dataset_folder=dataset_folder,
+                ds=ds,
+                source_project_id=SOURCE_PROJECT_ID,
+                source_dataset_name=SOURCE_DATASET_NAME,
+                destination_project_id=parse_destination_dataset_project_id,
+                sqls_folder=os.path.join(dags_folder, 'resources/stages/parse/sqls'),
+                parse_all_partitions=parse_all_partitions
+            )
+
+        dataset_name = get_dataset_name(dataset_folder)
+        parsing_operator = PythonOperator(
+            task_id=f'parse_tables_{dataset_name}',
+            python_callable=parse_v2_task,
+            execution_timeout=timedelta(minutes=60 * 4),
+            dag=dag
+        )
+
+        return parsing_operator
+
+    def create_add_view_task(dataset_name, view_name, sql):
+        def create_view_task(ds, **kwargs):
+            client = bigquery.Client()
+
+            dest_table_name = view_name
+            dest_table_ref = create_dataset(client, dataset_name, parse_destination_dataset_project_id).table(dest_table_name)
+
+            print('View sql: \n' + sql)
+
+            create_view(client, sql, dest_table_ref)
+
+        create_view_operator = PythonOperator(
+            task_id=f'create_view_{view_name}',
+            python_callable=create_view_task,
+            execution_timeout=timedelta(minutes=10),
+            dag=dag
+        )
+
+        return create_view_operator
+
+    def create_share_dataset_task(dataset_name):
+        def share_dataset_task(**kwargs):
+            if parse_destination_dataset_project_id != 'blockchain-etl':
+                logging.info('Skipping sharing dataset.')
+            else:
+                client = bigquery.Client()
+                share_dataset_all_users_read(client, f'{parse_destination_dataset_project_id}.{dataset_name}')
+                share_dataset_all_users_read(client, f'{parse_destination_dataset_project_id}-internal.{dataset_name}')
+
+        share_dataset_operator = PythonOperator(
+            task_id='share_dataset',
+            python_callable=share_dataset_task,
+            execution_timeout=timedelta(minutes=10),
+            dag=dag
+        )
+
+        return share_dataset_operator
+
+    wait_for_ethereum_load_dag_task = ExternalTaskSensor(
+        task_id='wait_for_ethereum_partition_dag',
+        external_dag_id=PARTITION_DAG_ID,
+        external_task_id='done',
+        execution_delta=timedelta(minutes=30),
+        priority_weight=0,
+        mode='reschedule',
+        poke_interval=5 * 60,
+        timeout=60 * 60 * 12,
+        dag=dag)
+
+    parse_v2_task = create_parse_v2_task()
+    wait_for_ethereum_load_dag_task >> parse_v2_task
+
+    checkpoint_task = BashOperator(
+        task_id='parse_all_checkpoint',
+        bash_command='echo parse_all_checkpoint',
+        priority_weight=1000,
+        dag=dag
+    )
+
+    parse_v2_task >> checkpoint_task
+
+    dataset_name = os.path.basename(dataset_folder)
+    full_dataset_name = 'ethereum_' + dataset_name
+
+    share_dataset_task = create_share_dataset_task(full_dataset_name)
+    checkpoint_task >> share_dataset_task
+
+    # Create views
+
+    sql_files = get_list_of_files(dataset_folder, '*.sql')
+    logging.info(sql_files)
+
+    for sql_file in sql_files:
+        sql = read_file(sql_file)
+        base_name = os.path.basename(sql_file)
+        view_name = os.path.splitext(base_name)[0]
+        create_view_task = create_add_view_task(full_dataset_name, view_name, sql)
+        checkpoint_task >> create_view_task
+
+    return dag
+
+
+def validate_definition_files(dataset_folder):
+    json_files = get_list_of_files(dataset_folder, '*.json')
+    dataset_folder_name = get_dataset_name(dataset_folder)
+
+    all_lowercase_table_names = []
+    for json_file in json_files:
+        file_name = json_file.split('/')[-1].replace('.json', '')
+
+        table_definition = read_json_file(json_file)
+        table = table_definition.get('table')
+        if not table:
+            raise ValueError(f'table is empty in file {json_file}')
+
+        dataset_name = table.get('dataset_name')
+        if not dataset_name:
+            raise ValueError(f'dataset_name is empty in file {json_file}')
+        if dataset_folder_name != dataset_name:
+            raise ValueError(f'dataset_name {dataset_name} is not equal to dataset_folder_name {dataset_folder_name}')
+
+        table_name = table.get('table_name')
+        if not table_name:
+            raise ValueError(f'table_name is empty in file {json_file}')
+        if file_name != table_name:
+            raise ValueError(f'file_name {file_name} doest match the table_name {table_name}')
+        all_lowercase_table_names.append(table_name.lower())
+
+    table_name_counts = collections.defaultdict(lambda: 0)
+    for table_name in all_lowercase_table_names:
+        table_name_counts[table_name] += 1
+
+    non_unique_table_names = [name for name, count in table_name_counts.items() if count > 1]
+
+    if len(non_unique_table_names) > 0:
+        raise ValueError(f'The following table names are not unique {",".join(non_unique_table_names)}')
+
+
+def get_dataset_name(dataset_folder):
+    return dataset_folder.split('/')[-1]

--- a/dags/ethereumetl_airflow/common.py
+++ b/dags/ethereumetl_airflow/common.py
@@ -1,4 +1,7 @@
 import json
+import logging
+import os
+from glob import glob
 
 
 def read_json_file(filepath):
@@ -11,3 +14,10 @@ def read_file(filepath):
     with open(filepath) as file_handle:
         content = file_handle.read()
         return content
+
+
+def get_list_of_files(dataset_folder, filter='*.json'):
+    logging.info('get_list_of_files')
+    logging.info(dataset_folder)
+    logging.info(os.path.join(dataset_folder, filter))
+    return [f for f in glob(os.path.join(dataset_folder, filter))]

--- a/dags/ethereumetl_airflow/parse/parse_dataset_folder_logic.py
+++ b/dags/ethereumetl_airflow/parse/parse_dataset_folder_logic.py
@@ -1,0 +1,67 @@
+import logging
+import time
+
+from ethereumetl_airflow.common import get_list_of_files, read_json_file
+from ethereumetl_airflow.parse.parse_logic import parse, ref_regex
+from ethereumetl_airflow.parse.toposort import toposort_flatten
+
+
+def parse_dataset_folder(
+        bigquery_client,
+        dataset_folder,
+        ds,
+        source_project_id,
+        source_dataset_name,
+        destination_project_id,
+        sqls_folder,
+        parse_all_partitions,
+        time_func=time.time
+):
+    logging.info(f'Parsing dataset folder {dataset_folder}')
+    json_files = get_list_of_files(dataset_folder, '*.json')
+    logging.info(json_files)
+
+    topologically_sorted_json_files = topologically_sort_json_files(json_files)
+    logging.info(f'Topologically sorted json files: {topologically_sorted_json_files}')
+
+    for index, json_file in enumerate(topologically_sorted_json_files):
+        logging.info(f'Parsing json file {index} out of {len(topologically_sorted_json_files)}: {json_file}')
+        table_definition = read_json_file(json_file)
+        parse(
+            bigquery_client,
+            table_definition,
+            ds,
+            source_project_id,
+            source_dataset_name,
+            destination_project_id,
+            sqls_folder,
+            parse_all_partitions,
+            time_func=time_func
+        )
+
+
+def topologically_sort_json_files(json_files):
+    table_name_to_file_map = {}
+    dependencies = {}
+
+    for json_file in json_files:
+        table_definition = read_json_file(json_file)
+
+        contract_address = table_definition['parser']['contract_address']
+
+        ref_dependencies = ref_regex.findall(contract_address) if contract_address is not None else None
+
+        table_name = get_table_name_from_json_file_name(json_file)
+
+        dependencies[table_name] = set(ref_dependencies)
+        table_name_to_file_map[table_name] = json_file
+
+    # TODO: Use toposort() instead of toposort_flatten() so that independent tables could be run in parallel
+    sorted_tables = list(toposort_flatten(dependencies))
+
+    topologically_sorted_json_files = [table_name_to_file_map[table_name] for table_name in sorted_tables]
+    return topologically_sorted_json_files
+
+
+def get_table_name_from_json_file_name(json_file_name):
+    return json_file_name.split('/')[-1].replace('.json', '')

--- a/dags/ethereumetl_airflow/parse/parse_dataset_folder_logic.py
+++ b/dags/ethereumetl_airflow/parse/parse_dataset_folder_logic.py
@@ -56,11 +56,20 @@ def topologically_sort_json_files(json_files):
         dependencies[table_name] = set(ref_dependencies)
         table_name_to_file_map[table_name] = json_file
 
+    validate_dependencies(dependencies, table_name_to_file_map.keys())
+
     # TODO: Use toposort() instead of toposort_flatten() so that independent tables could be run in parallel
     sorted_tables = list(toposort_flatten(dependencies))
 
     topologically_sorted_json_files = [table_name_to_file_map[table_name] for table_name in sorted_tables]
     return topologically_sorted_json_files
+
+
+def validate_dependencies(dependencies, table_names):
+    for deps in dependencies.values():
+        for dep_table_name in deps:
+            if dep_table_name not in table_names:
+                raise ValueError(f'Dependency {dep_table_name} not found. Check ref() in table definitions')
 
 
 def get_table_name_from_json_file_name(json_file_name):

--- a/dags/ethereumetl_airflow/parse/toposort.py
+++ b/dags/ethereumetl_airflow/parse/toposort.py
@@ -1,0 +1,96 @@
+#######################################################################
+# Implements a topological sort algorithm.
+#
+# Copyright 2014-2021 True Blade Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Notes:
+#  Based on http://code.activestate.com/recipes/578272-topological-sort
+#   with these major changes:
+#    Added unittests.
+#    Deleted doctests (maybe not the best idea in the world, but it cleans
+#     up the docstring).
+#    Moved functools import to the top of the file.
+#    Changed assert to a ValueError.
+#    Changed iter[items|keys] to [items|keys], for python 3
+#     compatibility. I don't think it matters for python 2 these are
+#     now lists instead of iterables.
+#    Copy the input so as to leave it unmodified.
+#    Renamed function from toposort2 to toposort.
+#    Handle empty input.
+#    Switch tests to use set literals.
+#
+########################################################################
+
+from functools import reduce as _reduce
+
+__all__ = ["toposort", "toposort_flatten", "CircularDependencyError"]
+__version__ = "1.7"
+
+
+class CircularDependencyError(ValueError):
+    def __init__(self, data):
+        # Sort the data just to make the output consistent, for use in
+        #  error messages.  That's convenient for doctests.
+        s = "Circular dependencies exist among these items: {{{}}}".format(
+            ", ".join(
+                "{!r}:{!r}".format(key, value) for key, value in sorted(data.items())
+            )
+        )
+        super(CircularDependencyError, self).__init__(s)
+        self.data = data
+
+
+def toposort(data):
+    """\
+Dependencies are expressed as a dictionary whose keys are items
+and whose values are a set of dependent items. Output is a list of
+sets in topological order. The first set consists of items with no
+dependences, each subsequent set consists of items that depend upon
+items in the preceeding sets."""
+
+    # Special case empty input.
+    if len(data) == 0:
+        return
+
+    # Copy the input so as to leave it unmodified.
+    # Discard self-dependencies and copy two levels deep.
+    data = {item: set(e for e in dep if e != item) for item, dep in data.items()}
+
+    # Find all items that don't depend on anything.
+    extra_items_in_deps = _reduce(set.union, data.values()) - set(data.keys())
+    # Add empty dependences where needed.
+    data.update({item: set() for item in extra_items_in_deps})
+    while True:
+        ordered = set(item for item, dep in data.items() if len(dep) == 0)
+        if not ordered:
+            break
+        yield ordered
+        data = {
+            item: (dep - ordered) for item, dep in data.items() if item not in ordered
+        }
+    if len(data) != 0:
+        raise CircularDependencyError(data)
+
+
+def toposort_flatten(data, sort=True):
+    """\
+Returns a single list of dependencies. For any set returned by
+toposort(), those items are sorted and appended to the result (just to
+make the results deterministic)."""
+
+    result = []
+    for d in toposort(data):
+        result.extend((sorted if sort else list)(d))
+    return result

--- a/run_parse_dataset.py
+++ b/run_parse_dataset.py
@@ -1,0 +1,27 @@
+import logging
+
+from google.cloud import bigquery
+
+from ethereumetl_airflow.parse.parse_dataset_folder_logic import parse_dataset_folder
+
+sqls_folder = 'dags/resources/stages/parse/sqls'
+
+project = '<your_gcp_project>'
+dataset = 'aelf'
+destination_project_id = 'blockchain-etl-dev'
+
+bigquery_client = bigquery.Client(project=project)
+
+logging_format = '%(asctime)s - %(name)s [%(levelname)s] - %(message)s'
+logging.basicConfig(level=logging.INFO, format=logging_format)
+
+parse_dataset_folder(
+    bigquery_client=bigquery_client,
+    dataset_folder=f'dags/resources/stages/parse/table_definitions/{dataset}',
+    ds='2022-11-01',
+    source_project_id='bigquery-public-data',
+    source_dataset_name='crypto_ethereum',
+    destination_project_id=destination_project_id,
+    sqls_folder=sqls_folder,
+    parse_all_partitions=False,
+)


### PR DESCRIPTION
## What?

- Run all table definitions in a single task to reduce load on Ariflow scheduler
- Don't read table definitions during DAG building stage to reduce load on Airflow scheduler

## Why? 

Airflow scheduler is the bottleneck

## Notes

This is a multistage deployment. In this PR only `aelf` and `curve` use parse_v2 DAG. If no issues are found, the remaining datasets will be upgraded

TODOs:

- Include toposort in requirements.txt, remove toposort.py
- Parse table definitions in parallel
- Add tests