### PR TITLE
Add cryptoswap factory and stableswap factory for curve

### DIFF
--- a/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_CryptoPoolDeployed.json
+++ b/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_CryptoPoolDeployed.json
@@ -1,0 +1,151 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "coins",
+                    "type": "address[2]"
+                },
+                {
+                    "indexed": false,
+                    "name": "A",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "gamma",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "mid_fee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "out_fee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "allowed_extra_profit",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fee_gamma",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "adjustment_step",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "admin_fee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "ma_half_time",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "initial_price",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "deployer",
+                    "type": "address"
+                }
+            ],
+            "name": "CryptoPoolDeployed",
+            "type": "event"
+        },
+        "contract_address": "0xf18056bbd320e96a48e3fbf8bc061322531aac99",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "coins",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "A",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "gamma",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "mid_fee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "out_fee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "allowed_extra_profit",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee_gamma",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "adjustment_step",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "admin_fee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "ma_half_time",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "initial_price",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "deployer",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FactoryCryptoSwap_event_CryptoPoolDeployed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_LiquidityGaugeDeployed.json
+++ b/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_LiquidityGaugeDeployed.json
@@ -1,0 +1,51 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "gauge",
+                    "type": "address"
+                }
+            ],
+            "name": "LiquidityGaugeDeployed",
+            "type": "event"
+        },
+        "contract_address": "0xf18056bbd320e96a48e3fbf8bc061322531aac99",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "gauge",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FactoryCryptoSwap_event_LiquidityGaugeDeployed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_TransferOwnership.json
+++ b/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_TransferOwnership.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "_old_owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "_new_owner",
+                    "type": "address"
+                }
+            ],
+            "name": "TransferOwnership",
+            "type": "event"
+        },
+        "contract_address": "0xf18056bbd320e96a48e3fbf8bc061322531aac99",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "_old_owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_new_owner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FactoryCryptoSwap_event_TransferOwnership"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_UpdateFeeReceiver.json
+++ b/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_UpdateFeeReceiver.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "_old_fee_receiver",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "_new_fee_receiver",
+                    "type": "address"
+                }
+            ],
+            "name": "UpdateFeeReceiver",
+            "type": "event"
+        },
+        "contract_address": "0xf18056bbd320e96a48e3fbf8bc061322531aac99",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "_old_fee_receiver",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_new_fee_receiver",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FactoryCryptoSwap_event_UpdateFeeReceiver"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_UpdateGaugeImplementation.json
+++ b/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_UpdateGaugeImplementation.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "_old_gauge_implementation",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "_new_gauge_implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "UpdateGaugeImplementation",
+            "type": "event"
+        },
+        "contract_address": "0xf18056bbd320e96a48e3fbf8bc061322531aac99",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "_old_gauge_implementation",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_new_gauge_implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FactoryCryptoSwap_event_UpdateGaugeImplementation"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_UpdatePoolImplementation.json
+++ b/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_UpdatePoolImplementation.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "_old_pool_implementation",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "_new_pool_implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "UpdatePoolImplementation",
+            "type": "event"
+        },
+        "contract_address": "0xf18056bbd320e96a48e3fbf8bc061322531aac99",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "_old_pool_implementation",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_new_pool_implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FactoryCryptoSwap_event_UpdatePoolImplementation"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_UpdateTokenImplementation.json
+++ b/dags/resources/stages/parse/table_definitions/curve/FactoryCryptoSwap_event_UpdateTokenImplementation.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "_old_token_implementation",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "_new_token_implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "UpdateTokenImplementation",
+            "type": "event"
+        },
+        "contract_address": "0xf18056bbd320e96a48e3fbf8bc061322531aac99",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "_old_token_implementation",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_new_token_implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FactoryCryptoSwap_event_UpdateTokenImplementation"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/curve/FactoryStableSwap_event_BasePoolAdded.json
+++ b/dags/resources/stages/parse/table_definitions/curve/FactoryStableSwap_event_BasePoolAdded.json
@@ -1,0 +1,31 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "base_pool",
+                    "type": "address"
+                }
+            ],
+            "name": "BasePoolAdded",
+            "type": "event"
+        },
+        "contract_address": "0xb9fc157394af804a3578134a6585c0dc9cc990d4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "base_pool",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FactoryStableSwap_event_BasePoolAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/curve/FactoryStableSwap_event_LiquidityGaugeDeployed.json
+++ b/dags/resources/stages/parse/table_definitions/curve/FactoryStableSwap_event_LiquidityGaugeDeployed.json
@@ -1,0 +1,41 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "gauge",
+                    "type": "address"
+                }
+            ],
+            "name": "LiquidityGaugeDeployed",
+            "type": "event"
+        },
+        "contract_address": "0xb9fc157394af804a3578134a6585c0dc9cc990d4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "gauge",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FactoryStableSwap_event_LiquidityGaugeDeployed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/curve/FactoryStableSwap_event_MetaPoolDeployed.json
+++ b/dags/resources/stages/parse/table_definitions/curve/FactoryStableSwap_event_MetaPoolDeployed.json
@@ -1,0 +1,71 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "coin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "base_pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "A",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "deployer",
+                    "type": "address"
+                }
+            ],
+            "name": "MetaPoolDeployed",
+            "type": "event"
+        },
+        "contract_address": "0xb9fc157394af804a3578134a6585c0dc9cc990d4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "coin",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "base_pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "A",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "deployer",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FactoryStableSwap_event_MetaPoolDeployed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/curve/FactoryStableSwap_event_PlainPoolDeployed.json
+++ b/dags/resources/stages/parse/table_definitions/curve/FactoryStableSwap_event_PlainPoolDeployed.json
@@ -1,0 +1,61 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "name": "coins",
+                    "type": "address[4]"
+                },
+                {
+                    "indexed": false,
+                    "name": "A",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "deployer",
+                    "type": "address"
+                }
+            ],
+            "name": "PlainPoolDeployed",
+            "type": "event"
+        },
+        "contract_address": "0xb9fc157394af804a3578134a6585c0dc9cc990d4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "coins",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "A",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "deployer",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "FactoryStableSwap_event_PlainPoolDeployed"
+    }
+}


### PR DESCRIPTION
## What?
Add table definitions for Curve's cryptoswap and stableswap factories.

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table defenitions

## Anything Else?
cryptoswap factory: 0xF18056Bbd320E96A48e3Fbf8bC061322531aac99
stableswap factory: 0xB9fC157394Af804a3578134A6585C0dc9cc990d4
