### PR TITLE
Don't read variables in a loop to prevent timeouts

### DIFF
--- a/dags/ethereum_parse_dag.py
+++ b/dags/ethereum_parse_dag.py
@@ -15,6 +15,11 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 var_prefix = 'ethereum_'
 
+parse_dag_vars = read_parse_dag_vars(
+    var_prefix=var_prefix,
+    schedule_interval='0 14 * * *'
+)
+
 for folder in glob(table_definitions_folder):
     dataset = folder.split('/')[-1]
 
@@ -24,9 +29,5 @@ for folder in glob(table_definitions_folder):
     globals()[dag_id] = build_parse_dag(
         dag_id=dag_id,
         dataset_folder=folder,
-        **read_parse_dag_vars(
-            var_prefix=var_prefix,
-            dataset=dataset,
-            schedule_interval='0 14 * * *'
-        )
+        **parse_dag_vars
     )

--- a/dags/ethereumetl_airflow/build_parse_dag.py
+++ b/dags/ethereumetl_airflow/build_parse_dag.py
@@ -34,9 +34,6 @@ def build_parse_dag(
 
     logging.info('parse_all_partitions is {}'.format(parse_all_partitions))
 
-    if parse_all_partitions:
-        dag_id = dag_id + '_FULL'
-
     if 'ethereum_kovan_parse' in dag_id:
         SOURCE_PROJECT_ID = 'public-data-finance'
         SOURCE_DATASET_NAME = 'crypto_ethereum_kovan'

--- a/dags/ethereumetl_airflow/variables.py
+++ b/dags/ethereumetl_airflow/variables.py
@@ -80,12 +80,12 @@ def read_amend_dag_vars(var_prefix, **kwargs):
 
     return vars
 
-def read_parse_dag_vars(var_prefix, dataset, **kwargs):
-    per_dataset_var_prefix = var_prefix + dataset + '_'
+
+def read_parse_dag_vars(var_prefix, **kwargs):
     vars = {
         'parse_destination_dataset_project_id': read_var('parse_destination_dataset_project_id', var_prefix, True, **kwargs),
         'schedule_interval': read_var('schedule_interval', var_prefix, True, **kwargs),
-        'parse_all_partitions': parse_bool(read_var('parse_all_partitions', per_dataset_var_prefix, False), default=None),
+        'parse_all_partitions': parse_bool(read_var('parse_all_partitions', var_prefix, False), default=None),
         'notification_emails': read_var('notification_emails', None, False, **kwargs),
     }
 


### PR DESCRIPTION
## What?

Don't read variables in a loop to prevent timeouts

## Why? 

It makes a call to the db every time Variable.get() is called which can cause timeouts if done in a loop