### PR TITLE
Reintroduce maker call definitions

### DIFF
--- a/dags/resources/stages/parse/table_definitions/maker/mcdFab_call_exit.json
+++ b/dags/resources/stages/parse/table_definitions/maker/mcdFab_call_exit.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "exit",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT `join` FROM ref('JoinFab_event_NewJoin')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "maker",
+        "schema": [
+            {
+                "description": "",
+                "name": "usr",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wad",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "mcdFab_call_exit"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/maker/mcdFab_call_join.json
+++ b/dags/resources/stages/parse/table_definitions/maker/mcdFab_call_join.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "usr",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "wad",
+                    "type": "uint256"
+                }
+            ],
+            "name": "join",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT `join` FROM ref('JoinFab_event_NewJoin')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "maker",
+        "schema": [
+            {
+                "description": "",
+                "name": "usr",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "wad",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "mcdFab_call_join"
+    }
+}


### PR DESCRIPTION
Reintroduce maker call definitions originally added in https://github.com/blockchain-etl/ethereum-etl-airflow/pull/437 and removed in https://github.com/blockchain-etl/ethereum-etl-airflow/pull/439 because of issues with parsing. The issue was in the query used in the `contract_address`: `join` is a reserved SQL keyword, so it needed to be quoted in backticks.

Tables have already been parsed:
```sql
SELECT * FROM `blockchain-etl.ethereum_maker.mcdFab_call_exit`;
SELECT * FROM `blockchain-etl.ethereum_maker.mcdFab_call_join`;
```

cc @AyadiGithub
