### PR TITLE
adding support for Bancor v3 PoolCollection

### DIFF
--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DefaultTradingFeePPMUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DefaultTradingFeePPMUpdated.json
@@ -19,7 +19,7 @@
             "name": "DefaultTradingFeePPMUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref('BancorNetworkV3_event_PoolCreated')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DefaultTradingFeePPMUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DefaultTradingFeePPMUpdated.json
@@ -19,7 +19,7 @@
             "name": "DefaultTradingFeePPMUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DefaultTradingFeePPMUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DefaultTradingFeePPMUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "prevFeePPM",
+                    "type": "uint32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "newFeePPM",
+                    "type": "uint32"
+                }
+            ],
+            "name": "DefaultTradingFeePPMUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "prevFeePPM",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFeePPM",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolCollection_event_DefaultTradingFeePPMUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DepositingEnabled.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DepositingEnabled.json
@@ -19,7 +19,7 @@
             "name": "DepositingEnabled",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DepositingEnabled.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DepositingEnabled.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bool",
+                    "name": "newStatus",
+                    "type": "bool"
+                }
+            ],
+            "name": "DepositingEnabled",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newStatus",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolCollection_event_DepositingEnabled"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DepositingEnabled.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_DepositingEnabled.json
@@ -19,7 +19,7 @@
             "name": "DepositingEnabled",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref('BancorNetworkV3_event_PoolCreated')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_OwnerUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_OwnerUpdate.json
@@ -19,7 +19,7 @@
             "name": "OwnerUpdate",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT FROM ref(`BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_OwnerUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_OwnerUpdate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "prevOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerUpdate",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "prevOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolCollection_event_OwnerUpdate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_OwnerUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_OwnerUpdate.json
@@ -19,7 +19,7 @@
             "name": "OwnerUpdate",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT FROM ref(`BancorNetworkV3_event_PoolCreated`)",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_OwnerUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_OwnerUpdate.json
@@ -19,7 +19,7 @@
             "name": "OwnerUpdate",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref('BancorNetworkV3_event_PoolCreated')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensDeposited.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensDeposited.json
@@ -37,7 +37,7 @@
             "name": "TokensDeposited",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref('BancorNetworkV3_event_PoolCreated')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensDeposited.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensDeposited.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "contextId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "provider",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "baseTokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "poolTokenAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TokensDeposited",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "contextId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "provider",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "baseTokenAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "poolTokenAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolCollection_event_TokensDeposited"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensDeposited.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensDeposited.json
@@ -37,7 +37,7 @@
             "name": "TokensDeposited",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensWithdrawn.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensWithdrawn.json
@@ -55,7 +55,7 @@
             "name": "TokensWithdrawn",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref('BancorNetworkV3_event_PoolCreated')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensWithdrawn.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensWithdrawn.json
@@ -55,7 +55,7 @@
             "name": "TokensWithdrawn",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensWithdrawn.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TokensWithdrawn.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "contextId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "provider",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "baseTokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "poolTokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "externalProtectionBaseTokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "bntAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "withdrawalFeeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TokensWithdrawn",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "contextId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "provider",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "baseTokenAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "poolTokenAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "externalProtectionBaseTokenAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "bntAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "withdrawalFeeAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolCollection_event_TokensWithdrawn"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TotalLiquidityUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TotalLiquidityUpdated.json
@@ -37,7 +37,7 @@
             "name": "TotalLiquidityUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref('BancorNetworkV3_event_PoolCreated')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TotalLiquidityUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TotalLiquidityUpdated.json
@@ -37,7 +37,7 @@
             "name": "TotalLiquidityUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TotalLiquidityUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TotalLiquidityUpdated.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "contextId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidity",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "stakedBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "poolTokenSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TotalLiquidityUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "contextId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidity",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stakedBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "poolTokenSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolCollection_event_TotalLiquidityUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingEnabled.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingEnabled.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bool",
+                    "name": "newStatus",
+                    "type": "bool"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint8",
+                    "name": "reason",
+                    "type": "uint8"
+                }
+            ],
+            "name": "TradingEnabled",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newStatus",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "reason",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolCollection_event_TradingEnabled"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingEnabled.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingEnabled.json
@@ -25,7 +25,7 @@
             "name": "TradingEnabled",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingEnabled.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingEnabled.json
@@ -25,7 +25,7 @@
             "name": "TradingEnabled",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref('BancorNetworkV3_event_PoolCreated')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingFeePPMUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingFeePPMUpdated.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "prevFeePPM",
+                    "type": "uint32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "newFeePPM",
+                    "type": "uint32"
+                }
+            ],
+            "name": "TradingFeePPMUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "prevFeePPM",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFeePPM",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolCollection_event_TradingFeePPMUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingFeePPMUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingFeePPMUpdated.json
@@ -25,7 +25,7 @@
             "name": "TradingFeePPMUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingFeePPMUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingFeePPMUpdated.json
@@ -25,7 +25,7 @@
             "name": "TradingFeePPMUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref('BancorNetworkV3_event_PoolCreated')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingLiquidityUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingLiquidityUpdated.json
@@ -37,7 +37,7 @@
             "name": "TradingLiquidityUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingLiquidityUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingLiquidityUpdated.json
@@ -37,7 +37,7 @@
             "name": "TradingLiquidityUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`BancorNetworkV3_event_PoolCreated`)",
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref('BancorNetworkV3_event_PoolCreated')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingLiquidityUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/bancor/PoolCollection_event_TradingLiquidityUpdated.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "contextId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract Token",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "prevLiquidity",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newLiquidity",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TradingLiquidityUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT poolCollection FROM ref(`blockchain-etl.ethereum_bancor.BancorNetworkV3_event_PoolCreated`)",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bancor",
+        "schema": [
+            {
+                "description": "",
+                "name": "contextId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "prevLiquidity",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newLiquidity",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolCollection_event_TradingLiquidityUpdated"
+    }
+}


### PR DESCRIPTION
## What?
ie: Add support for Bancor V3's PoolCollection contracts 

## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) 


## Anything Else?
For contract address, I got all the distinct poolcollection addresses returned by the PoolCreated event in the bancornetowrkv3 contract
