### PR TITLE
Add aave v3 events ahead of Ethereum deployment

### DIFF
--- a/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AToken_v3_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_BalanceTransfer.json
+++ b/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_BalanceTransfer.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BalanceTransfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AToken_v3_event_BalanceTransfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_Burn.json
+++ b/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_Burn.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "target",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "target",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AToken_v3_event_Burn"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_Initialized.json
+++ b/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_Initialized.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "treasury",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "aTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "aTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "aTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "treasury",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "aTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "aTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "aTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AToken_v3_event_Initialized"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_Mint.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "caller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AToken_v3_event_Mint"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/aave/AToken_v3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT aToken FROM ref('PoolConfigurator_event_ReserveInitialized') group by aToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "AToken_v3_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ATokenUpgraded.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ATokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "ATokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ATokenUpgraded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BorrowCapChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BorrowCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldBorrowCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBorrowCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBorrowCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BorrowCapChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "borrowable",
+                    "type": "bool"
+                }
+            ],
+            "name": "BorrowableInIsolationChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrowable",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BorrowableInIsolationChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldBridgeProtocolFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBridgeProtocolFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BridgeProtocolFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldBridgeProtocolFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBridgeProtocolFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BridgeProtocolFeeUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "ltv",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationBonus",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CollateralConfigurationChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "ltv",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationThreshold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationBonus",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_CollateralConfigurationChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_DebtCeilingChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_DebtCeilingChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldDebtCeiling",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newDebtCeiling",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DebtCeilingChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldDebtCeiling",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newDebtCeiling",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_DebtCeilingChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "oldCategoryId",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "newCategoryId",
+                    "type": "uint8"
+                }
+            ],
+            "name": "EModeAssetCategoryChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldCategoryId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCategoryId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_EModeAssetCategoryChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_EModeCategoryAdded.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_EModeCategoryAdded.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint8",
+                    "name": "categoryId",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "ltv",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationBonus",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "label",
+                    "type": "string"
+                }
+            ],
+            "name": "EModeCategoryAdded",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "categoryId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "ltv",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationThreshold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationBonus",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracle",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "label",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_EModeCategoryAdded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldFlashloanPremiumToProtocol",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newFlashloanPremiumToProtocol",
+                    "type": "uint128"
+                }
+            ],
+            "name": "FlashloanPremiumToProtocolUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFlashloanPremiumToProtocol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFlashloanPremiumToProtocol",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_FlashloanPremiumToProtocolUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldFlashloanPremiumTotal",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newFlashloanPremiumTotal",
+                    "type": "uint128"
+                }
+            ],
+            "name": "FlashloanPremiumTotalUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFlashloanPremiumTotal",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFlashloanPremiumTotal",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_FlashloanPremiumTotalUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidationProtocolFeeChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_LiquidationProtocolFeeChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveActive.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveActive.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "active",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveActive",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "active",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveActive"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveBorrowing.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveBorrowing.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "enabled",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveBorrowing",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "enabled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveBorrowing"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveDropped.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveDropped.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveDropped",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveDropped"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveFactorChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveFactorChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldReserveFactor",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newReserveFactor",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReserveFactorChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldReserveFactor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newReserveFactor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveFactorChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveFrozen.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveFrozen.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "frozen",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveFrozen",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "frozen",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveFrozen"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveInitialized.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveInitialized.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "aToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "stableDebtToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "variableDebtToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "interestRateStrategyAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveInitialized",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "aToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stableDebtToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "variableDebtToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "interestRateStrategyAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveInitialized"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldStrategy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newStrategy",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveInterestRateStrategyChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldStrategy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newStrategy",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveInterestRateStrategyChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReservePaused.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReservePaused.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "paused",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReservePaused",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "paused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReservePaused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "enabled",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveStableRateBorrowing",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "enabled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveStableRateBorrowing"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "oldState",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "newState",
+                    "type": "bool"
+                }
+            ],
+            "name": "SiloedBorrowingChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldState",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newState",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_SiloedBorrowingChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "StableDebtTokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_StableDebtTokenUpgraded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_SupplyCapChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_SupplyCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldSupplyCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSupplyCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldSupplyCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_SupplyCapChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldUnbackedMintCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newUnbackedMintCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "UnbackedMintCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldUnbackedMintCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newUnbackedMintCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_UnbackedMintCapChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "VariableDebtTokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_VariableDebtTokenUpgraded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_BackUnbacked.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_BackUnbacked.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "backer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "fee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BackUnbacked",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "backer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_BackUnbacked"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Borrow.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "enum DataTypes.InterestRateMode",
+                    "name": "interestRateMode",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "borrowRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint16",
+                    "name": "referralCode",
+                    "type": "uint16"
+                }
+            ],
+            "name": "Borrow",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "interestRateMode",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrowRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "referralCode",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_Borrow"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_FlashLoan.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_FlashLoan.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "target",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "initiator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "enum DataTypes.InterestRateMode",
+                    "name": "interestRateMode",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "premium",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint16",
+                    "name": "referralCode",
+                    "type": "uint16"
+                }
+            ],
+            "name": "FlashLoan",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "target",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "initiator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "interestRateMode",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "premium",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "referralCode",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_FlashLoan"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_IsolationModeTotalDebtUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_IsolationModeTotalDebtUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "totalDebt",
+                    "type": "uint256"
+                }
+            ],
+            "name": "IsolationModeTotalDebtUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "totalDebt",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_IsolationModeTotalDebtUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_LiquidationCall.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_LiquidationCall.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "collateralAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "debtAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "debtToCover",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidatedCollateralAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "liquidator",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "receiveAToken",
+                    "type": "bool"
+                }
+            ],
+            "name": "LiquidationCall",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "collateralAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtToCover",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidatedCollateralAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidator",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "receiveAToken",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_LiquidationCall"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_MintUnbacked.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_MintUnbacked.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint16",
+                    "name": "referralCode",
+                    "type": "uint16"
+                }
+            ],
+            "name": "MintUnbacked",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "referralCode",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_MintUnbacked"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_MintedToTreasury.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_MintedToTreasury.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountMinted",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MintedToTreasury",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountMinted",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_MintedToTreasury"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_RebalanceStableBorrowRate.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_RebalanceStableBorrowRate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                }
+            ],
+            "name": "RebalanceStableBorrowRate",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_RebalanceStableBorrowRate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Repay.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Repay.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "repayer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "useATokens",
+                    "type": "bool"
+                }
+            ],
+            "name": "Repay",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "repayer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "useATokens",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_Repay"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveDataUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveDataUpdated.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidityRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "stableBorrowRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "variableBorrowRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidityIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "variableBorrowIndex",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReserveDataUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidityRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stableBorrowRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "variableBorrowRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidityIndex",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "variableBorrowIndex",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_ReserveDataUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveUsedAsCollateralDisabled.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveUsedAsCollateralDisabled.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveUsedAsCollateralDisabled",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_ReserveUsedAsCollateralDisabled"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveUsedAsCollateralEnabled.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveUsedAsCollateralEnabled.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveUsedAsCollateralEnabled",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_ReserveUsedAsCollateralEnabled"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Supply.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Supply.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint16",
+                    "name": "referralCode",
+                    "type": "uint16"
+                }
+            ],
+            "name": "Supply",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "referralCode",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_Supply"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_SwapBorrowRateMode.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_SwapBorrowRateMode.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "enum DataTypes.InterestRateMode",
+                    "name": "interestRateMode",
+                    "type": "uint8"
+                }
+            ],
+            "name": "SwapBorrowRateMode",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "interestRateMode",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_SwapBorrowRateMode"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_UserEModeSet.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_UserEModeSet.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "categoryId",
+                    "type": "uint8"
+                }
+            ],
+            "name": "UserEModeSet",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "categoryId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_UserEModeSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Withdraw.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Withdraw.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "reserve",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdraw",
+            "type": "event"
+        },
+        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "reserve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Pool_v3_event_Withdraw"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_BorrowAllowanceDelegated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_Burn.json
+++ b/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_Burn.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Burn"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_Initialized.json
+++ b/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Initialized"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_Mint.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Mint"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_v3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_v3_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_BorrowAllowanceDelegated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_Burn.json
+++ b/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_Burn.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "target",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "target",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Burn"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_Initialized.json
+++ b/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Initialized"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_Mint.json
+++ b/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_Mint.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "caller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Mint"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_v3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_event_ReserveInitialized') GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_v3_event_Transfer"
+    }
+}


### PR DESCRIPTION
## What?
Ahead of the Aave team's deployment of Aave V3 contracts, we'd like to index these log events. The only thing that needs to be updated in this PR upon deployment would be the pool configuration and pool addresses since they cannot be set to what they are currently due to those addresses on Ethereum already being EOA.

## How? 
Copied from [Avalanche table definitions directly](https://github.com/nansen-ai/evmchain-etl-table-definitions/tree/main/parse/table_definitions_avalanche/aave). 


## Related PRs (optional)

## Anything Else?
