### PR TITLE
Use actually deployed addresses

### DIFF
--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ATokenUpgraded.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ATokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "ATokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BorrowCapChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BorrowCapChanged.json
@@ -25,7 +25,7 @@
             "name": "BorrowCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
@@ -19,7 +19,7 @@
             "name": "BorrowableInIsolationChanged",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
@@ -19,7 +19,7 @@
             "name": "BridgeProtocolFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
@@ -31,7 +31,7 @@
             "name": "CollateralConfigurationChanged",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_DebtCeilingChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_DebtCeilingChanged.json
@@ -25,7 +25,7 @@
             "name": "DebtCeilingChanged",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
@@ -25,7 +25,7 @@
             "name": "EModeAssetCategoryChanged",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_EModeCategoryAdded.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_EModeCategoryAdded.json
@@ -43,7 +43,7 @@
             "name": "EModeCategoryAdded",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
@@ -19,7 +19,7 @@
             "name": "FlashloanPremiumToProtocolUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
@@ -19,7 +19,7 @@
             "name": "FlashloanPremiumTotalUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
@@ -25,7 +25,7 @@
             "name": "LiquidationProtocolFeeChanged",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveActive.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveActive.json
@@ -19,7 +19,7 @@
             "name": "ReserveActive",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveBorrowing.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveBorrowing.json
@@ -19,7 +19,7 @@
             "name": "ReserveBorrowing",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveDropped.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveDropped.json
@@ -13,7 +13,7 @@
             "name": "ReserveDropped",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveFactorChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveFactorChanged.json
@@ -25,7 +25,7 @@
             "name": "ReserveFactorChanged",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveFrozen.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveFrozen.json
@@ -19,7 +19,7 @@
             "name": "ReserveFrozen",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveInitialized.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveInitialized.json
@@ -37,7 +37,7 @@
             "name": "ReserveInitialized",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
@@ -25,7 +25,7 @@
             "name": "ReserveInterestRateStrategyChanged",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReservePaused.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReservePaused.json
@@ -19,7 +19,7 @@
             "name": "ReservePaused",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
@@ -19,7 +19,7 @@
             "name": "ReserveStableRateBorrowing",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
@@ -25,7 +25,7 @@
             "name": "SiloedBorrowingChanged",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "StableDebtTokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_SupplyCapChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_SupplyCapChanged.json
@@ -25,7 +25,7 @@
             "name": "SupplyCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
@@ -25,7 +25,7 @@
             "name": "UnbackedMintCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
+++ b/dags/resources/stages/parse/table_definitions/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "VariableDebtTokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
+        "contract_address": "0x64b761d848206f447fe2dd461b0c635ec39ebb27",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_BackUnbacked.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_BackUnbacked.json
@@ -31,7 +31,7 @@
             "name": "BackUnbacked",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Borrow.json
@@ -49,7 +49,7 @@
             "name": "Borrow",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_FlashLoan.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_FlashLoan.json
@@ -49,7 +49,7 @@
             "name": "FlashLoan",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_IsolationModeTotalDebtUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_IsolationModeTotalDebtUpdated.json
@@ -19,7 +19,7 @@
             "name": "IsolationModeTotalDebtUpdated",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_LiquidationCall.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_LiquidationCall.json
@@ -49,7 +49,7 @@
             "name": "LiquidationCall",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_MintUnbacked.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_MintUnbacked.json
@@ -37,7 +37,7 @@
             "name": "MintUnbacked",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_MintedToTreasury.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_MintedToTreasury.json
@@ -19,7 +19,7 @@
             "name": "MintedToTreasury",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_RebalanceStableBorrowRate.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_RebalanceStableBorrowRate.json
@@ -19,7 +19,7 @@
             "name": "RebalanceStableBorrowRate",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Repay.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Repay.json
@@ -37,7 +37,7 @@
             "name": "Repay",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveDataUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveDataUpdated.json
@@ -43,7 +43,7 @@
             "name": "ReserveDataUpdated",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveUsedAsCollateralDisabled.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveUsedAsCollateralDisabled.json
@@ -19,7 +19,7 @@
             "name": "ReserveUsedAsCollateralDisabled",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveUsedAsCollateralEnabled.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_ReserveUsedAsCollateralEnabled.json
@@ -19,7 +19,7 @@
             "name": "ReserveUsedAsCollateralEnabled",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Supply.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Supply.json
@@ -37,7 +37,7 @@
             "name": "Supply",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_SwapBorrowRateMode.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_SwapBorrowRateMode.json
@@ -25,7 +25,7 @@
             "name": "SwapBorrowRateMode",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_UserEModeSet.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_UserEModeSet.json
@@ -19,7 +19,7 @@
             "name": "UserEModeSet",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Withdraw.json
+++ b/dags/resources/stages/parse/table_definitions/aave/Pool_v3_event_Withdraw.json
@@ -31,7 +31,7 @@
             "name": "Withdraw",
             "type": "event"
         },
-        "contract_address": "0x794a61358d6845594f94dc1db02a252b5b4814ad",
+        "contract_address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
## What?
Using the actually deployed [Pool](https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2) and [PoolConfigurator](https://etherscan.io/address/0x64b761D848206f447Fe2dd461b0c635Ec39EbB27) contract addresses taken from the official Aave contracts [here](https://github.com/bgd-labs/aave-address-book/blob/main/src/AaveV3Ethereum.sol)

## How? 
I replaced all the strings via shell command

## Related PRs (optional)
[PRs that are related to this or may need to be deployed before this PR](https://github.com/blockchain-etl/ethereum-etl-airflow/pull/498) was the original PR that added these events

## Anything Else?
