### PR TITLE
Add cWETHv3 events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_AbsorbCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_AbsorbCollateral.json
@@ -37,7 +37,7 @@
             "name": "AbsorbCollateral",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
         "field_mapping": {},
         "type": "log"
     },
@@ -71,6 +71,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "cUSDCv3_event_AbsorbCollateral"
+        "table_name": "cWETHv3_event_AbsorbCollateral"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_AbsorbCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_AbsorbCollateral.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "absorber",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collateralAbsorbed",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "usdValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AbsorbCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "absorber",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateralAbsorbed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "usdValue",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_AbsorbCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_AbsorbDebt.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_AbsorbDebt.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "absorber",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "basePaidOut",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "usdValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AbsorbDebt",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "absorber",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "basePaidOut",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "usdValue",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_AbsorbDebt"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_AbsorbDebt.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_AbsorbDebt.json
@@ -31,7 +31,7 @@
             "name": "AbsorbDebt",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
         "field_mapping": {},
         "type": "log"
     },
@@ -60,6 +60,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "cUSDCv3_event_AbsorbDebt"
+        "table_name": "cWETHv3_event_AbsorbDebt"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_BuyCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_BuyCollateral.json
@@ -31,7 +31,7 @@
             "name": "BuyCollateral",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
         "field_mapping": {},
         "type": "log"
     },
@@ -60,6 +60,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "cUSDCv3_event_BuyCollateral"
+        "table_name": "cWETHv3_event_BuyCollateral"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_BuyCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_BuyCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "buyer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "baseAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collateralAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BuyCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "buyer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "baseAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateralAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_BuyCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_PauseAction.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_PauseAction.json
@@ -37,7 +37,7 @@
             "name": "PauseAction",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
         "field_mapping": {},
         "type": "log"
     },
@@ -71,6 +71,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "cUSDCv3_event_PauseAction"
+        "table_name": "cWETHv3_event_PauseAction"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_PauseAction.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_PauseAction.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "supplyPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "transferPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "withdrawPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "absorbPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "buyPaused",
+                    "type": "bool"
+                }
+            ],
+            "name": "PauseAction",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "supplyPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "transferPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "withdrawPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "absorbPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "buyPaused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_PauseAction"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Supply.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Supply.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Supply",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dst",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_Supply"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Supply.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Supply.json
@@ -25,7 +25,7 @@
             "name": "Supply",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
         "field_mapping": {},
         "type": "log"
     },
@@ -49,6 +49,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "cUSDCv3_event_Supply"
+        "table_name": "cWETHv3_event_Supply"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_SupplyCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_SupplyCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dst",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_SupplyCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_SupplyCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_SupplyCollateral.json
@@ -31,7 +31,7 @@
             "name": "SupplyCollateral",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
         "field_mapping": {},
         "type": "log"
     },
@@ -60,6 +60,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "cUSDCv3_event_SupplyCollateral"
+        "table_name": "cWETHv3_event_SupplyCollateral"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
         "field_mapping": {},
         "type": "log"
     },
@@ -49,6 +49,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "cUSDCv3_event_Transfer"
+        "table_name": "cWETHv3_event_Transfer"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_TransferCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_TransferCollateral.json
@@ -31,7 +31,7 @@
             "name": "TransferCollateral",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
         "field_mapping": {},
         "type": "log"
     },
@@ -60,6 +60,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "cUSDCv3_event_TransferCollateral"
+        "table_name": "cWETHv3_event_TransferCollateral"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_TransferCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_TransferCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TransferCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_TransferCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Withdraw.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Withdraw.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdraw",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "src",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_Withdraw"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Withdraw.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_Withdraw.json
@@ -25,7 +25,7 @@
             "name": "Withdraw",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
         "field_mapping": {},
         "type": "log"
     },
@@ -49,6 +49,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "cUSDCv3_event_Withdraw"
+        "table_name": "cWETHv3_event_Withdraw"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_WithdrawCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_WithdrawCollateral.json
@@ -31,7 +31,7 @@
             "name": "WithdrawCollateral",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
         "field_mapping": {},
         "type": "log"
     },
@@ -60,6 +60,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "cUSDCv3_event_WithdrawCollateral"
+        "table_name": "cWETHv3_event_WithdrawCollateral"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_WithdrawCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_WithdrawCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "src",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_WithdrawCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_WithdrawReserves.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_WithdrawReserves.json
@@ -19,7 +19,7 @@
             "name": "WithdrawReserves",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
         "field_mapping": {},
         "type": "log"
     },
@@ -38,6 +38,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "cUSDCv3_event_WithdrawReserves"
+        "table_name": "cWETHv3_event_WithdrawReserves"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_WithdrawReserves.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cWETHv3_event_WithdrawReserves.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawReserves",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_WithdrawReserves"
+    }
+}


### PR DESCRIPTION
## What?
Adds cWETHv3 events for Compound V3

## How? 
Copied the files for cUSDCv3 from https://github.com/blockchain-etl/ethereum-etl-airflow/commit/c428a8a69d9d3e3b91e06b42cd9d488179750034 and replaced the contract_address with the value from https://docs.compound.finance/ and changed the table name to match.
## Related PRs (optional)
PRs that are related to this or may need to be deployed before this PR

## Anything Else?
