### PR TITLE
Bug fix for WETH tables

### DIFF
--- a/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_Borrow.json
+++ b/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_Borrow.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "0x29babff3eba7b517a75109ea8fd6d1eab4a10258",
+        "contract_address": "0xc4d4500326981eacd020e20a81b1c479c161c7ef",
         "abi": {
             "anonymous": false,
             "inputs": [

--- a/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_BorrowAtMaturity.json
+++ b/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_BorrowAtMaturity.json
@@ -7,8 +7,20 @@
             "inputs": [
                 {
                     "indexed": true,
+                    "internalType": "uint256",
+                    "name": "maturity",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
                     "internalType": "address",
                     "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "receiver",
                     "type": "address"
                 },
                 {
@@ -26,22 +38,32 @@
                 {
                     "indexed": false,
                     "internalType": "uint256",
-                    "name": "shares",
+                    "name": "fee",
                     "type": "uint256"
                 }
             ],
-            "name": "Repay",
+            "name": "BorrowAtMaturity",
             "type": "event"
         },
         "field_mapping": {}
     },
     "table": {
         "dataset_name": "exactly",
-        "table_name": "ExactlyMarketWETH_event_Repay",
+        "table_name": "ExactlyMarketWETH_event_BorrowAtMaturity",
         "table_description": "",
         "schema": [
             {
+                "name": "maturity",
+                "description": "",
+                "type": "STRING"
+            },
+            {
                 "name": "caller",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "receiver",
                 "description": "",
                 "type": "STRING"
             },
@@ -56,7 +78,7 @@
                 "type": "STRING"
             },
             {
-                "name": "shares",
+                "name": "fee",
                 "description": "",
                 "type": "STRING"
             }

--- a/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_Deposit.json
+++ b/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_Deposit.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "0x29babff3eba7b517a75109ea8fd6d1eab4a10258",
+        "contract_address": "0xc4d4500326981eacd020e20a81b1c479c161c7ef",
         "abi": {
             "anonymous": false,
             "inputs": [

--- a/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_DepositAtMaturity.json
+++ b/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_DepositAtMaturity.json
@@ -1,10 +1,22 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "0x29babff3eba7b517a75109ea8fd6d1eab4a10258",
+        "contract_address": "0xc4d4500326981eacd020e20a81b1c479c161c7ef",
         "abi": {
             "anonymous": false,
             "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "maturity",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
                 {
                     "indexed": true,
                     "internalType": "address",
@@ -12,40 +24,50 @@
                     "type": "address"
                 },
                 {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "assets",
+                    "type": "uint256"
                 },
                 {
                     "indexed": false,
                     "internalType": "uint256",
-                    "name": "amount",
+                    "name": "fee",
                     "type": "uint256"
                 }
             ],
-            "name": "Approval",
+            "name": "DepositAtMaturity",
             "type": "event"
         },
         "field_mapping": {}
     },
     "table": {
         "dataset_name": "exactly",
-        "table_name": "ExactlyMarketWETH_event_Approval",
+        "table_name": "ExactlyMarketWETH_event_DepositAtMaturity",
         "table_description": "",
         "schema": [
+            {
+                "name": "maturity",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "caller",
+                "description": "",
+                "type": "STRING"
+            },
             {
                 "name": "owner",
                 "description": "",
                 "type": "STRING"
             },
             {
-                "name": "spender",
+                "name": "assets",
                 "description": "",
                 "type": "STRING"
             },
             {
-                "name": "amount",
+                "name": "fee",
                 "description": "",
                 "type": "STRING"
             }

--- a/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_Liquidate.json
+++ b/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_Liquidate.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "0x29babff3eba7b517a75109ea8fd6d1eab4a10258",
+        "contract_address": "0xc4d4500326981eacd020e20a81b1c479c161c7ef",
         "abi": {
             "anonymous": false,
             "inputs": [

--- a/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_RepayAtMaturity.json
+++ b/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_RepayAtMaturity.json
@@ -7,6 +7,12 @@
             "inputs": [
                 {
                     "indexed": true,
+                    "internalType": "uint256",
+                    "name": "maturity",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
                     "internalType": "address",
                     "name": "caller",
                     "type": "address"
@@ -26,20 +32,25 @@
                 {
                     "indexed": false,
                     "internalType": "uint256",
-                    "name": "shares",
+                    "name": "positionAssets",
                     "type": "uint256"
                 }
             ],
-            "name": "Repay",
+            "name": "RepayAtMaturity",
             "type": "event"
         },
         "field_mapping": {}
     },
     "table": {
         "dataset_name": "exactly",
-        "table_name": "ExactlyMarketWETH_event_Repay",
+        "table_name": "ExactlyMarketWETH_event_RepayAtMaturity",
         "table_description": "",
         "schema": [
+            {
+                "name": "maturity",
+                "description": "",
+                "type": "STRING"
+            },
             {
                 "name": "caller",
                 "description": "",
@@ -56,7 +67,7 @@
                 "type": "STRING"
             },
             {
-                "name": "shares",
+                "name": "positionAssets",
                 "description": "",
                 "type": "STRING"
             }

--- a/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_Transfer.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "0x29babff3eba7b517a75109ea8fd6d1eab4a10258",
+        "contract_address": "0xc4d4500326981eacd020e20a81b1c479c161c7ef",
         "abi": {
             "anonymous": false,
             "inputs": [

--- a/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_Withdraw.json
+++ b/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_Withdraw.json
@@ -1,7 +1,7 @@
 {
     "parser": {
         "type": "log",
-        "contract_address": "0x29babff3eba7b517a75109ea8fd6d1eab4a10258",
+        "contract_address": "0xc4d4500326981eacd020e20a81b1c479c161c7ef",
         "abi": {
             "anonymous": false,
             "inputs": [

--- a/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_WithdrawAtMaturity.json
+++ b/dags/resources/stages/parse/table_definitions/exactly/ExactlyMarketWETH_event_WithdrawAtMaturity.json
@@ -7,6 +7,12 @@
             "inputs": [
                 {
                     "indexed": true,
+                    "internalType": "uint256",
+                    "name": "maturity",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
                     "internalType": "address",
                     "name": "caller",
                     "type": "address"
@@ -14,49 +20,65 @@
                 {
                     "indexed": true,
                     "internalType": "address",
-                    "name": "borrower",
+                    "name": "receiver",
                     "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "positionAssets",
+                    "type": "uint256"
                 },
                 {
                     "indexed": false,
                     "internalType": "uint256",
                     "name": "assets",
                     "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "shares",
-                    "type": "uint256"
                 }
             ],
-            "name": "Repay",
+            "name": "WithdrawAtMaturity",
             "type": "event"
         },
         "field_mapping": {}
     },
     "table": {
         "dataset_name": "exactly",
-        "table_name": "ExactlyMarketWETH_event_Repay",
+        "table_name": "ExactlyMarketWETH_event_WithdrawAtMaturity",
         "table_description": "",
         "schema": [
+            {
+                "name": "maturity",
+                "description": "",
+                "type": "STRING"
+            },
             {
                 "name": "caller",
                 "description": "",
                 "type": "STRING"
             },
             {
-                "name": "borrower",
+                "name": "receiver",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "owner",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "positionAssets",
                 "description": "",
                 "type": "STRING"
             },
             {
                 "name": "assets",
-                "description": "",
-                "type": "STRING"
-            },
-            {
-                "name": "shares",
                 "description": "",
                 "type": "STRING"
             }


### PR DESCRIPTION
## What?
Bug fix to use WETH proxy address instead of WETH router proxy address
Would have to delete existing `ExactlyMarketWETH_event_xxx` tables in BigQuery and reload
Added a few tables ExactlyMarketWETH_event_xxxAtMaturity`

## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) or cli tools to build the table defenitions

