### PR TITLE
overarching cToken events for compound v3

### DIFF
--- a/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_AbsorbCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_AbsorbCollateral.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "absorber",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collateralAbsorbed",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "usdValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AbsorbCollateral",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "absorber",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateralAbsorbed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "usdValue",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cTokenv3_event_AbsorbCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_AbsorbDebt.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_AbsorbDebt.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "absorber",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "basePaidOut",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "usdValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AbsorbDebt",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "absorber",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "basePaidOut",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "usdValue",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cTokenv3_event_AbsorbDebt"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_BuyCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_BuyCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "buyer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "baseAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collateralAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BuyCollateral",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "buyer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "baseAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateralAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cTokenv3_event_BuyCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_PauseAction.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_PauseAction.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "supplyPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "transferPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "withdrawPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "absorbPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "buyPaused",
+                    "type": "bool"
+                }
+            ],
+            "name": "PauseAction",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "supplyPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "transferPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "withdrawPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "absorbPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "buyPaused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cTokenv3_event_PauseAction"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_Supply.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_Supply.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Supply",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dst",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cTokenv3_event_Supply"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_SupplyCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_SupplyCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyCollateral",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dst",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cTokenv3_event_SupplyCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_Transfer.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cTokenv3_event_Transfer"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_TransferCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_TransferCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TransferCollateral",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cTokenv3_event_TransferCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_Withdraw.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_Withdraw.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdraw",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "src",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cTokenv3_event_Withdraw"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_WithdrawCollateral.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_WithdrawCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawCollateral",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "src",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cTokenv3_event_WithdrawCollateral"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_WithdrawReserves.json
+++ b/dags/resources/stages/parse/table_definitions/compound/cTokenv3_event_WithdrawReserves.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawReserves",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cTokenv3_event_WithdrawReserves"
+    }
+}


### PR DESCRIPTION
## What?
Add support for cToken (right now just cUSDCv3 and cWETHv3) events for compound v3

## How? 
I copied the json files for cUSDCv3 and replaced the table names to be cTokenv3_event_{event name} and replaced contract_address with "SELECT DISTINCT(cometProxy) FROM ref('Configurator_v3_event_CometDeployed')"

## Anything Else?
hi! there's no Comptroller for Compound v3 so there was no mirror to the "MarketListed" used for the cToken events in v2 - in general v3 is just very different from v2 but I do think looking at the distinct cometProxys from the CometDeployed events should get both v3 cToken addresses! 