### PR TITLE
add Dodo calls

### DIFF
--- a/dags/resources/stages/parse/table_definitions/dodo/DODOV2Proxy_call_createDODOPrivatePool.json
+++ b/dags/resources/stages/parse/table_definitions/dodo/DODOV2Proxy_call_createDODOPrivatePool.json
@@ -59,7 +59,7 @@
             "stateMutability": "payable",
             "type": "function"
         },
-        "contract_address": "0xff7c8f518e6f1435957ed3d3e0692c94676dae7a",
+        "contract_address": "SELECT '0xa356867fdcea8e71aeaf87805808803806231fdc' UNION ALL SELECT '0x9ae501385bc7996a2a4a1fbb00c8d3820611bcb5'",
         "field_mapping": {},
         "type": "trace"
     },
@@ -113,6 +113,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "DPPFactoryProxy_createDODOPrivatePool"
+        "table_name": "DODOV2Proxy_call_createDODOPrivatePool"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/dodo/DPPFactoryProxy_call_createDODOPrivatePool.json
+++ b/dags/resources/stages/parse/table_definitions/dodo/DPPFactoryProxy_call_createDODOPrivatePool.json
@@ -1,0 +1,118 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "baseToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "quoteToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "baseInAmount",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "quoteInAmount",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "lpFeeRate",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "i",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "k",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "isOpenTwap",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "deadLine",
+                    "type": "uint256"
+                }
+            ],
+            "name": "createDODOPrivatePool",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "newPrivatePool",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0xff7c8f518e6f1435957ed3d3e0692c94676dae7a",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "dodo",
+        "schema": [
+            {
+                "description": "",
+                "name": "baseToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "quoteToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "baseInAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "quoteInAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "lpFeeRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "i",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "k",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "isOpenTwap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "deadLine",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "DPPFactoryProxy_call_createDODOPrivatePool"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/dodo/DPSFactory_call_createDODOStablePool.json
+++ b/dags/resources/stages/parse/table_definitions/dodo/DPSFactory_call_createDODOStablePool.json
@@ -83,6 +83,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "DPSFactory_createDODOStablePool"
+        "table_name": "DPSFactory_call_createDODOStablePool"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/dodo/DVMFactory_call_createDODOVendingMachine.json
+++ b/dags/resources/stages/parse/table_definitions/dodo/DVMFactory_call_createDODOVendingMachine.json
@@ -83,6 +83,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "DVMFactory_createDODOVendingMachine"
+        "table_name": "DVMFactory_call_createDODOVendingMachine"
     }
 }


### PR DESCRIPTION
## What?
Decode createDODOPrivatePool calls for DODOV2Proxy contracts
Also, update 3 table name to make it clear they encode function calls

## How? 
I used https://contract-parser.d5.ai/

## Related PRs (optional)
In PR #533 I decoded pool creation function calls on three other factory contracts but forgot to include "_call_" in the table name to make it easier to read