### PR TITLE
add Dodo contract version

### DIFF
--- a/dags/resources/stages/parse/table_definitions/dodo/DPPFactory_event_NewDPP.json
+++ b/dags/resources/stages/parse/table_definitions/dodo/DPPFactory_event_NewDPP.json
@@ -31,7 +31,7 @@
             "name": "NewDPP",
             "type": "event"
         },
-        "contract_address": "0x5336ede8f971339f6c0e304c66ba16f1296a2fbe",
+        "contract_address": "SELECT * FROM UNNEST(['0x5336ede8f971339f6c0e304c66ba16f1296a2fbe', '0x6b4fa0bc61eddc928e0df9c7f01e407bfcd3e5ef'])",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
## What?
In the `DPPFactory_event_NewDPP` table add another version of the `DPP_Factory` contract which also emits `NewDPP` events

## How? 
I added the alternate version in the `contract` field of the existing table, i.e. `"SELECT * FROM UNNEST(['0x5336ede8f971339f6c0e304c66ba16f1296a2fbe', '0x6b4fa0bc61eddc928e0df9c7f01e407bfcd3e5ef'])"`

If it's preferable to create a separate new table (e.g. `DPPFactory_V1` and `DPPFactory_V2`), let me know. 

## Related PRs (optional)
This modifies a table created in PR #461: https://github.com/blockchain-etl/ethereum-etl-airflow/pull/461/commits/bdbc514a02d82c571ac74234dd071f4de16dad55
