### PR TITLE
Update composer schedules and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Create a new Cloud Composer environment:
 export ENVIRONMENT_NAME=ethereum-etl-0
 
 AIRFLOW_CONFIGS_ARR=(
-    "celery-worker_concurrency=12"
-    "core-parallelism=48"
+    "celery-worker_concurrency=8"
     "scheduler-dag_dir_list_interval=300"
     "scheduler-min_file_process_interval=120"
 )
@@ -35,14 +34,14 @@ gcloud composer environments create \
     --environment-size=medium \
     --scheduler-cpu=2 \
     --scheduler-memory=13 \
-    --scheduler-storage=2 \
-    --scheduler-count=2 \
+    --scheduler-storage=1 \
+    --scheduler-count=1 \
     --web-server-cpu=1 \
     --web-server-memory=2 \
-    --web-server-storage=1 \
-    --worker-cpu=4 \
-    --worker-memory=26 \
-    --worker-storage=4 \
+    --web-server-storage=512MB \
+    --worker-cpu=2 \
+    --worker-memory=13 \
+    --worker-storage=1 \
     --min-workers=1 \
     --max-workers=8 \
     --airflow-configs=$AIRFLOW_CONFIGS

--- a/dags/ethereum_amend_dag.py
+++ b/dags/ethereum_amend_dag.py
@@ -14,6 +14,6 @@ DAG = build_amend_dag(
     chain='ethereum',
     **read_amend_dag_vars(
         var_prefix='ethereum_',
-        schedule_interval='30 12 * * *'
+        schedule_interval='30 8 * * *'
     )
 )

--- a/dags/ethereum_export_dag.py
+++ b/dags/ethereum_export_dag.py
@@ -8,7 +8,7 @@ DAG = build_export_dag(
     dag_id='ethereum_export_dag',
     **read_export_dag_vars(
         var_prefix='ethereum_',
-        export_schedule_interval='0 12 * * *',
+        export_schedule_interval='0 8 * * *',
         export_start_date='2015-07-30',
         export_max_workers=10,
         export_batch_size=10,

--- a/dags/ethereum_load_dag.py
+++ b/dags/ethereum_load_dag.py
@@ -21,7 +21,7 @@ if cloud_provider == 'gcp':
         chain='ethereum',
         **read_load_dag_vars(
             var_prefix='ethereum_',
-            schedule_interval='30 12 * * *'
+            schedule_interval='30 8 * * *'
         )
     )
 elif cloud_provider == 'aws':

--- a/dags/ethereum_parse_dag.py
+++ b/dags/ethereum_parse_dag.py
@@ -17,7 +17,7 @@ var_prefix = 'ethereum_'
 
 parse_dag_vars = read_parse_dag_vars(
     var_prefix=var_prefix,
-    schedule_interval='0 14 * * *'
+    schedule_interval='0 10 * * *'
 )
 
 for folder in glob(table_definitions_folder):

--- a/dags/ethereum_partition_dag.py
+++ b/dags/ethereum_partition_dag.py
@@ -18,5 +18,5 @@ DAG = build_partition_dag(
     public_dataset_name = 'crypto_ethereum',
     load_dag_id='ethereum_load_dag',
     notification_emails=Variable.get('notification_emails', None),
-    schedule_interval='30 13 * * *',
+    schedule_interval='30 9 * * *',
 )

--- a/dags/ethereumetl_airflow/build_clean_dag.py
+++ b/dags/ethereumetl_airflow/build_clean_dag.py
@@ -68,7 +68,7 @@ def build_clean_dag(
             task_id=f'wait_{dataset}_parse_dag',
             external_dag_id=f'ethereum_parse_{dataset}_dag',
             external_task_id='parse_all_checkpoint',
-            execution_delta=timedelta(hours=9),
+            execution_delta=timedelta(hours=13),
             priority_weight=0,
             mode='reschedule',
             poke_interval=5 * 60,


### PR DESCRIPTION
Push the daily dag schedules back by 4 hours.

Also, after Parse v2 DAG, Composer resources can be down-rated significantly. This PR to update docs with suggested config.

### Testing
- updated schedules working in our Dev Composer
- downrated config already working in both Dev and Prod Composers

### Related PRs
https://github.com/blockchain-etl/ethereum-etl-airflow/pull/466
https://github.com/blockchain-etl/ethereum-etl-airflow/pull/467
https://github.com/blockchain-etl/ethereum-etl-airflow/pull/470

