### PR TITLE
Add withdrawals (EIP-4895) 

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,49 +1,33 @@
-x-airflow: &airflow-common
-  build:
-    context: .
-    dockerfile: ./docker/Dockerfile
-  environment:
-    AIRFLOW__CORE__SQL_ALCHEMY_CONN: sqlite:////home/airflow_db/airflow.db
-    AIRFLOW__CORE__LOAD_EXAMPLES: "false"
-    AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: "false"
-    AIRFLOW__CORE__LOGGING_LEVEL: INFO
-    AIRFLOW__SECRETS__BACKEND: airflow.secrets.local_filesystem.LocalFilesystemBackend
-    AIRFLOW__SECRETS__BACKEND_KWARGS: '{"variables_file_path":"/root/airflow/variables.json"}'
-    AIRFLOW__WEBSERVER__WORKERS: 1
-    # For BigQuery auth issues, see https://stackoverflow.com/a/66032397
-    AIRFLOW_CONN_BIGQUERY_DEFAULT: "google-cloud-platform://?extra__google_cloud_platform__project=${CLOUDSDK_CORE_PROJECT}"
-    AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT: "google-cloud-platform://?extra__google_cloud_platform__project=${CLOUDSDK_CORE_PROJECT}"
-    DAGS_FOLDER: /root/airflow/dags
-    CLOUDSDK_CORE_PROJECT:
-    GCLOUD_PROJECT: ${CLOUDSDK_CORE_PROJECT}
-    GOOGLE_CLOUD_PROJECT: ${CLOUDSDK_CORE_PROJECT}
-  volumes:
-    - airflow_db:/home/airflow_db
-    - airflow_logs:/root/airflow/logs
-    - ./dags:/root/airflow/dags
-    - ./docker/variables.json:/root/airflow/variables.json
-    - ./docker/webserver_config_local.py:/root/airflow/webserver_config.py:ro
-    - ~/.config/gcloud:/root/.config/gcloud
-
 services:
-  _airflow_initdb:
-    <<: *airflow-common
-    command: ["db", "init"]
-
-  _airflow_scheduler:
-    <<: *airflow-common
-    command: ["scheduler"]
-    depends_on:
-      - _airflow_initdb
-    restart: on-failure # Might fail if "db init" has not succeeded yet.
-
   airflow:
-    <<: *airflow-common
-    command: ["webserver"]
-    depends_on:
-      - _airflow_scheduler
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+    command: ["standalone"]
+    environment:
+      AIRFLOW__CORE__SQL_ALCHEMY_CONN: sqlite:////home/airflow_db/airflow.db
+      AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+      AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: "false"
+      AIRFLOW__CORE__LOGGING_LEVEL: INFO
+      AIRFLOW__SECRETS__BACKEND: airflow.secrets.local_filesystem.LocalFilesystemBackend
+      AIRFLOW__SECRETS__BACKEND_KWARGS: '{"variables_file_path":"/root/airflow/variables.json"}'
+      AIRFLOW__WEBSERVER__WORKERS: 1
+      # For BigQuery auth issues, see https://stackoverflow.com/a/66032397
+      AIRFLOW_CONN_BIGQUERY_DEFAULT: "google-cloud-platform://?extra__google_cloud_platform__project=${CLOUDSDK_CORE_PROJECT}"
+      AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT: "google-cloud-platform://?extra__google_cloud_platform__project=${CLOUDSDK_CORE_PROJECT}"
+      DAGS_FOLDER: /root/airflow/dags
+      CLOUDSDK_CORE_PROJECT:
+      GCLOUD_PROJECT: ${CLOUDSDK_CORE_PROJECT}
+      GOOGLE_CLOUD_PROJECT: ${CLOUDSDK_CORE_PROJECT}
     ports:
       - 8080:8080
+    volumes:
+      - airflow_db:/home/airflow_db
+      - airflow_logs:/root/airflow/logs
+      - ./dags:/root/airflow/dags
+      - ./docker/variables.json:/root/airflow/variables.json
+      - ./docker/webserver_config_local.py:/root/airflow/webserver_config.py:ro
+      - ~/.config/gcloud:/root/.config/gcloud
 
 volumes:
   # Used to persist metadata across runs:

--- a/dags/resources/stages/enrich/schemas/blocks.json
+++ b/dags/resources/stages/enrich/schemas/blocks.json
@@ -97,5 +97,38 @@
         "name": "base_fee_per_gas",
         "type": "INT64",
         "description": "Protocol base fee per gas, which can move up or down"
+    },
+    {
+        "name": "withdrawals_root",
+        "type": "STRING",
+        "description": "The root of the withdrawal trie of the block"
+    },
+    {
+        "name": "withdrawals",
+        "type": "RECORD",
+        "fields": [
+            {
+                "name": "index",
+                "type": "INT64",
+                "description": ""
+            },
+            {
+                "name": "validator_index",
+                "type": "INT64",
+                "description": ""
+            },
+            {
+                "name": "address",
+                "type": "STRING",
+                "description": ""
+            },
+            {
+                "name": "amount",
+                "type": "STRING",
+                "description": ""
+            }
+        ],
+        "mode": "REPEATED",
+        "description": "Validator withdrawals"
     }
 ]

--- a/dags/resources/stages/enrich/sqls/blocks.sql
+++ b/dags/resources/stages/enrich/sqls/blocks.sql
@@ -17,7 +17,9 @@ SELECT
     blocks.gas_limit,
     blocks.gas_used,
     blocks.transaction_count,
-    blocks.base_fee_per_gas
+    blocks.base_fee_per_gas,
+    blocks.withdrawals_root,
+    blocks.withdrawals,
 FROM {{params.dataset_name_raw}}.blocks AS blocks
 where true
     {% if not params.load_all_partitions %}

--- a/dags/resources/stages/enrich/sqls/merge/merge_blocks.sql
+++ b/dags/resources/stages/enrich/sqls/merge/merge_blocks.sql
@@ -21,7 +21,9 @@ insert (
     gas_limit,
     gas_used,
     transaction_count,
-    base_fee_per_gas
+    base_fee_per_gas,
+    withdrawals_root,
+    withdrawals
 ) values (
     timestamp,
     number,
@@ -41,7 +43,9 @@ insert (
     gas_limit,
     gas_used,
     transaction_count,
-    base_fee_per_gas
+    base_fee_per_gas,
+    withdrawals_root,
+    withdrawals
 )
 when not matched by source and date(timestamp) = '{{ds}}' then
 delete

--- a/dags/resources/stages/raw/schemas/blocks.json
+++ b/dags/resources/stages/raw/schemas/blocks.json
@@ -97,5 +97,38 @@
         "name": "base_fee_per_gas",
         "type": "INT64",
         "description": "Protocol base fee per gas, which can move up or down"
+    },
+    {
+        "name": "withdrawals_root",
+        "type": "STRING",
+        "description": "The root of the withdrawal trie of the block"
+    },
+    {
+        "name": "withdrawals",
+        "type": "RECORD",
+        "fields": [
+            {
+                "name": "index",
+                "type": "INT64",
+                "description": ""
+            },
+            {
+                "name": "validator_index",
+                "type": "INT64",
+                "description": ""
+            },
+            {
+                "name": "address",
+                "type": "STRING",
+                "description": ""
+            },
+            {
+                "name": "amount",
+                "type": "STRING",
+                "description": ""
+            }
+        ],
+        "mode": "REPEATED",
+        "description": "Validator withdrawals"
     }
 ]

--- a/docs/eip_4895_migration.md
+++ b/docs/eip_4895_migration.md
@@ -1,0 +1,20 @@
+Run the following in BigQuery:
+
+```sql
+ALTER TABLE `your-project.your-dataset.blocks` ADD COLUMN IF NOT EXISTS withdrawals_root STRING
+    OPTIONS(description="The root of the withdrawal trie of the block");
+ALTER TABLE `your-project.your-dataset.blocks` ADD COLUMN IF NOT EXISTS withdrawals ARRAY<STRUCT<index INT64, validator_index INT64, address STRING, amount STRING>>
+    OPTIONS(description="Validator withdrawals");
+```
+
+To delete the new columns:
+
+```sql
+ALTER TABLE `your-project.your-dataset.blocks` DROP COLUMN withdrawals_root;
+ALTER TABLE `your-project.your-dataset.blocks` DROP COLUMN withdrawals;
+```
+
+EIP-4895 notes:
+
+- Shapella Mainnet Announcement: https://blog.ethereum.org/2023/03/28/shapella-mainnet-announcement
+- Shapella upgrade will go live on mainnet at epoch **194048**

--- a/requirements_airflow.txt
+++ b/requirements_airflow.txt
@@ -1,2 +1,2 @@
 eth-hash==0.3.3         # Fixes install conflicts issue in Composer
-ethereum-etl==2.0.3
+ethereum-etl==2.2.0


### PR DESCRIPTION
See https://github.com/blockchain-etl/ethereum-etl/pull/434 for more context.

Updates schemas and SQL to support the new `withdrawals` and `withdrawals_root` fields that will be introduced as part of the Shanghai/Shapella upgrade. See [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895).

New columns should be added automatically.
