### PR TITLE
Added missed events for balancer_v2 MetaStable and Stable pools

### DIFF
--- a/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_AmpUpdateStarted.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_AmpUpdateStarted.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "startValue",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "endValue",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "startTime",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "endTime",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AmpUpdateStarted",
+            "type": "event"
+        },
+        "contract_address": "SELECT pool FROM ref('V2_MetaStablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "startValue",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "endValue",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "startTime",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "endTime",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_MetaStablePool_event_AmpUpdateStarted"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_AmpUpdateStopped.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_AmpUpdateStopped.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AmpUpdateStopped",
+            "type": "event"
+        },
+        "contract_address": "SELECT pool FROM ref('V2_MetaStablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "currentValue",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_MetaStablePool_event_AmpUpdateStopped"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT pool FROM ref('V2_MetaStablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_MetaStablePool_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_OracleEnabledChanged.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_OracleEnabledChanged.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "enabled",
+                    "type": "bool"
+                }
+            ],
+            "name": "OracleEnabledChanged",
+            "type": "event"
+        },
+        "contract_address": "SELECT pool FROM ref('V2_MetaStablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "enabled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_MetaStablePool_event_OracleEnabledChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_PausedStateChanged.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_PausedStateChanged.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "paused",
+                    "type": "bool"
+                }
+            ],
+            "name": "PausedStateChanged",
+            "type": "event"
+        },
+        "contract_address": "SELECT pool FROM ref('V2_MetaStablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "paused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_MetaStablePool_event_PausedStateChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_PriceRateCacheUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_PriceRateCacheUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IERC20",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "rate",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PriceRateCacheUpdated",
+            "type": "event"
+        },
+        "contract_address": "SELECT pool FROM ref('V2_MetaStablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "rate",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_MetaStablePool_event_PriceRateCacheUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_PriceRateProviderSet.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_PriceRateProviderSet.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "contract IERC20",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract IRateProvider",
+                    "name": "provider",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "cacheDuration",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PriceRateProviderSet",
+            "type": "event"
+        },
+        "contract_address": "SELECT pool FROM ref('V2_MetaStablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "provider",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "cacheDuration",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_MetaStablePool_event_PriceRateProviderSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_SwapFeePercentageChanged.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_MetaStablePool_event_SwapFeePercentageChanged.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "swapFeePercentage",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SwapFeePercentageChanged",
+            "type": "event"
+        },
+        "contract_address": "SELECT pool FROM ref('V2_MetaStablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "swapFeePercentage",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_MetaStablePool_event_SwapFeePercentageChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_StablePool_event_AmpUpdateStarted.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_StablePool_event_AmpUpdateStarted.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "startValue",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "endValue",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "startTime",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "endTime",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AmpUpdateStarted",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT pool FROM ref('V2_StablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "startValue",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "endValue",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "startTime",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "endTime",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_StablePool_event_AmpUpdateStarted"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_StablePool_event_AmpUpdateStopped.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_StablePool_event_AmpUpdateStopped.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AmpUpdateStopped",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT pool FROM ref('V2_StablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "currentValue",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_StablePool_event_AmpUpdateStopped"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_StablePool_event_Approval.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_StablePool_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT pool FROM ref('V2_StablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_StablePool_event_Approval"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_StablePool_event_PausedStateChanged.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_StablePool_event_PausedStateChanged.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "paused",
+                    "type": "bool"
+                }
+            ],
+            "name": "PausedStateChanged",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT pool FROM ref('V2_StablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "paused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_StablePool_event_PausedStateChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/balancer/V2_StablePool_event_SwapFeePercentageChanged.json
+++ b/dags/resources/stages/parse/table_definitions/balancer/V2_StablePool_event_SwapFeePercentageChanged.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "swapFeePercentage",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SwapFeePercentageChanged",
+            "type": "event"
+        },
+        "contract_address": "SELECT DISTINCT pool FROM ref('V2_StablePoolFactory_event_PoolCreated')",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "balancer",
+        "schema": [
+            {
+                "description": "",
+                "name": "swapFeePercentage",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "V2_StablePool_event_SwapFeePercentageChanged"
+    }
+}


### PR DESCRIPTION
## What?
Added missing events for Balancer V2_MetaStablePool and V2_StablePool 

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table defenitions

## Future plans:
We will use those events to estimate price impact on balancer stable pools (e.g. StablePool, ComposableStablePool, MetaStablePool and also Curve pools)
