### PR TITLE
Upgrade composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export AIRFLOW_CONFIGS=$(IFS=, ; echo "${AIRFLOW_CONFIGS_ARR[*]}")
 gcloud composer environments create \
     $ENVIRONMENT_NAME \
     --location=us-central1 \
-    --image-version=composer-2.0.25-airflow-2.2.5 \
+    --image-version=composer-2.1.14-airflow-2.5.1 \
     --environment-size=medium \
     --scheduler-cpu=2 \
     --scheduler-memory=13 \
@@ -41,7 +41,7 @@ gcloud composer environments create \
     --web-server-storage=512MB \
     --worker-cpu=2 \
     --worker-memory=13 \
-    --worker-storage=1 \
+    --worker-storage=10 \
     --min-workers=1 \
     --max-workers=8 \
     --airflow-configs=$AIRFLOW_CONFIGS

--- a/dags/ethereumetl_airflow/build_export_dag.py
+++ b/dags/ethereumetl_airflow/build_export_dag.py
@@ -35,6 +35,7 @@ def build_export_dag(
         output_bucket,
         cloud_provider,
         export_start_date,
+        export_end_date=None,
         notification_emails=None,
         export_schedule_interval='0 0 * * *',
         export_max_workers=10,
@@ -46,6 +47,7 @@ def build_export_dag(
     default_dag_args = {
         "depends_on_past": False,
         "start_date": export_start_date,
+        "end_date": export_end_date,
         "email_on_failure": True,
         "email_on_retry": False,
         "retries": export_retries,

--- a/dags/ethereumetl_airflow/build_load_dag.py
+++ b/dags/ethereumetl_airflow/build_load_dag.py
@@ -30,6 +30,8 @@ def build_load_dag(
     chain='ethereum',
     notification_emails=None,
     load_start_date=datetime(2018, 7, 1),
+    load_end_date=None,
+    load_catchup=False,
     schedule_interval='0 0 * * *',
     load_all_partitions=True
 ):
@@ -61,6 +63,7 @@ def build_load_dag(
     default_dag_args = {
         'depends_on_past': False,
         'start_date': load_start_date,
+        'end_date': load_end_date,
         'email_on_failure': True,
         'email_on_retry': False,
         'retries': 5,
@@ -73,7 +76,7 @@ def build_load_dag(
     # Define a DAG (directed acyclic graph) of tasks.
     dag = models.DAG(
         dag_id,
-        catchup=False,
+        catchup=load_catchup,
         schedule_interval=schedule_interval,
         default_args=default_dag_args)
 

--- a/dags/ethereumetl_airflow/variables.py
+++ b/dags/ethereumetl_airflow/variables.py
@@ -7,6 +7,9 @@ def read_export_dag_vars(var_prefix, **kwargs):
     export_start_date = read_var('export_start_date', var_prefix, True, **kwargs)
     export_start_date = datetime.strptime(export_start_date, '%Y-%m-%d')
     
+    export_end_date = read_var('export_end_date', var_prefix, False, **kwargs)
+    export_end_date = datetime.strptime(export_end_date, '%Y-%m-%d') if export_end_date is not None else None
+    
     provider_uris = read_var('provider_uris', var_prefix, True, **kwargs)
     provider_uris = [uri.strip() for uri in provider_uris.split(',')]
 
@@ -24,6 +27,7 @@ def read_export_dag_vars(var_prefix, **kwargs):
         'output_bucket': read_var('output_bucket', var_prefix, True, **kwargs),
         'cloud_provider': cloud_provider,
         'export_start_date': export_start_date,
+        'export_end_date': export_end_date,
         'export_schedule_interval': read_var('export_schedule_interval', var_prefix, True, **kwargs),
         'provider_uris': provider_uris,
         'provider_uris_archival': provider_uris_archival,
@@ -60,13 +64,19 @@ def read_load_dag_vars(var_prefix, **kwargs):
         'destination_dataset_project_id': read_var('destination_dataset_project_id', var_prefix, True, **kwargs),
         'notification_emails': read_var('notification_emails', None, False, **kwargs),
         'schedule_interval': read_var('schedule_interval', var_prefix, True, **kwargs),
-        'load_all_partitions': parse_bool(read_var('load_all_partitions', var_prefix, True, **kwargs))
+        'load_all_partitions': parse_bool(read_var('load_all_partitions', var_prefix, True, **kwargs)),
+        'load_catchup': parse_bool(read_var('load_catchup', var_prefix, False, **kwargs))
     }
 
-    load_start_date = read_var('load_start_date', vars, False, **kwargs)
+    load_start_date = read_var('load_start_date', var_prefix, False, **kwargs)
     if load_start_date is not None:
         load_start_date = datetime.strptime(load_start_date, '%Y-%m-%d')
         vars['load_start_date'] = load_start_date
+
+    load_end_date = read_var('load_end_date', var_prefix, False, **kwargs)
+    if load_end_date is not None:
+        load_end_date = datetime.strptime(load_end_date, '%Y-%m-%d')
+        vars['load_end_date'] = load_end_date
 
     return vars
 

--- a/requirements_airflow.txt
+++ b/requirements_airflow.txt
@@ -1,2 +1,5 @@
-eth-hash==0.3.3         # Fixes install conflicts issue in Composer
-ethereum-etl==2.2.0
+eth-hash<0.4            # Fixes install conflicts issue in Composer
+ethereum-etl==2.2.1     # Requires web3>=5.29,<6
+# web3>5.31.0,<6 requires protobuf==3.19.5 which conflicts with `composer-2.1.14-airflow-2.5.1`.
+# web3==5.31.0 is the latest version that has the more relaxed protobuf>=3.10.0,<4 requirement.
+web3==5.31.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,3 @@
+black
+crcmod==1.7     # matches `composer-2.1.14-airflow-2.5.1`
+isort

--- a/requirements_local.txt
+++ b/requirements_local.txt
@@ -1,4 +1,4 @@
-apache-airflow[google,postgres]==2.2.5      # similar to `composer-2.0.25-airflow-2.2.5`
-google-cloud-bigquery==2.34.4               # matches `composer-2.0.25-airflow-2.2.5`
-google-cloud-dataform==0.2.0                # matches `composer-2.0.25-airflow-2.2.5`
-google-cloud-storage==1.44.0                # matches `composer-2.0.25-airflow-2.2.5`
+apache-airflow[gcp,postgres]==2.5.1      # similar to `composer-2.1.14-airflow-2.5.1`
+google-api-core==2.8.1                      # matches `composer-2.1.14-airflow-2.5.1`
+google-cloud-bigquery==2.34.4               # matches `composer-2.1.14-airflow-2.5.1`
+google-cloud-storage==2.7.0                 # matches `composer-2.1.14-airflow-2.5.1`

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,2 @@
-jsonschema==3.2.0       # matches `composer-2.0.25-airflow-2.2.5`
+jsonschema==3.2.0       # matches `composer-2.1.14-airflow-2.5.1`
 pytest


### PR DESCRIPTION
- update dependencies to match `` and/or latest versions
- also, add `(export|load)_end_date` & `load_catchup` parameters to help with running backfills
- retain the now-deprecated-but-still-working `schedule_interval` and not change these to the new syntax `schedule`, preferring some backwards compatibility ... for now

### Testing in Composer dev env
- [x] Updated `worker-storage` to 10GB (to match current Prod)
- [x] Clear dags folder entirely
- [x] Uninstall all pypi packages
- [x] Run update to `composer-2.1.14-airflow-2.5.1`
- [x] Install pypi packages as specified in `requirements_airflow.txt`
- [x] Re-populate dags folder from local
- [x] Manual interventions to remove [post-upgrade warnings](https://airflow.apache.org/docs/apache-airflow/2.5.1/installation/upgrading.html#post-upgrade-warnings)
- [x] Check for import errors
- [x] Check dags run sucessfully (export, load, partition, parse_common)
- [x] Data diff the output vs prod
