### PR TITLE
Add cToken_event_AccrueInterest_combined.sql

### DIFF
--- a/dags/resources/stages/parse/table_definitions/compound/cToken_event_AccrueInterest_combined.sql
+++ b/dags/resources/stages/parse/table_definitions/compound/cToken_event_AccrueInterest_combined.sql
@@ -1,24 +1,24 @@
 -- AccrueInterest for some tokens don't include the cashPrior field. This view combines events with both signatures
-SELECT * except(cashPrior)
+SELECT block_timestamp, block_number, transaction_hash, log_index, contract_address, cashPrior, interestAccumulated, borrowIndex, totalBorrows
 FROM `blockchain-etl.ethereum_compound.cToken_event_AccrueInterest` 
 UNION ALL
-SELECT *
+SELECT block_timestamp, block_number, transaction_hash, log_index, contract_address, null, interestAccumulated, borrowIndex, totalBorrows
 FROM `blockchain-etl.ethereum_compound.cUSDC_event_AccrueInterest`
 UNION ALL
-SELECT *
+SELECT block_timestamp, block_number, transaction_hash, log_index, contract_address, null, interestAccumulated, borrowIndex, totalBorrows
 FROM `blockchain-etl.ethereum_compound.cREP_event_AccrueInterest`
 UNION ALL
-SELECT *
+SELECT block_timestamp, block_number, transaction_hash, log_index, contract_address, null, interestAccumulated, borrowIndex, totalBorrows
 FROM `blockchain-etl.ethereum_compound.cBAT_event_AccrueInterest`
 UNION ALL
-SELECT *
+SELECT block_timestamp, block_number, transaction_hash, log_index, contract_address, null, interestAccumulated, borrowIndex, totalBorrows
 FROM `blockchain-etl.ethereum_compound.cETH_event_AccrueInterest`
 UNION ALL
-SELECT *
+SELECT block_timestamp, block_number, transaction_hash, log_index, contract_address, null, interestAccumulated, borrowIndex, totalBorrows
 FROM `blockchain-etl.ethereum_compound.cSAI_event_AccrueInterest`
 UNION ALL
-SELECT *
+SELECT block_timestamp, block_number, transaction_hash, log_index, contract_address, null, interestAccumulated, borrowIndex, totalBorrows
 FROM `blockchain-etl.ethereum_compound.cWBTC_event_AccrueInterest`
 UNION ALL
-SELECT *
+SELECT block_timestamp, block_number, transaction_hash, log_index, contract_address, null, interestAccumulated, borrowIndex, totalBorrows
 FROM `blockchain-etl.ethereum_compound.cZRX_event_AccrueInterest`

--- a/dags/resources/stages/parse/table_definitions/compound/cToken_event_AccrueInterest_combined.sql
+++ b/dags/resources/stages/parse/table_definitions/compound/cToken_event_AccrueInterest_combined.sql
@@ -1,0 +1,24 @@
+-- AccrueInterest for some tokens don't include the cashPrior field. This view combines events with both signatures
+SELECT * except(cashPrior)
+FROM `blockchain-etl.ethereum_compound.cToken_event_AccrueInterest` 
+UNION ALL
+SELECT *
+FROM `blockchain-etl.ethereum_compound.cUSDC_event_AccrueInterest`
+UNION ALL
+SELECT *
+FROM `blockchain-etl.ethereum_compound.cREP_event_AccrueInterest`
+UNION ALL
+SELECT *
+FROM `blockchain-etl.ethereum_compound.cBAT_event_AccrueInterest`
+UNION ALL
+SELECT *
+FROM `blockchain-etl.ethereum_compound.cETH_event_AccrueInterest`
+UNION ALL
+SELECT *
+FROM `blockchain-etl.ethereum_compound.cSAI_event_AccrueInterest`
+UNION ALL
+SELECT *
+FROM `blockchain-etl.ethereum_compound.cWBTC_event_AccrueInterest`
+UNION ALL
+SELECT *
+FROM `blockchain-etl.ethereum_compound.cZRX_event_AccrueInterest`


### PR DESCRIPTION
## What?

Add cToken_event_AccrueInterest_combined.sql that combines AccrueInterest events with different signatures.

## Why? 

Some compound v2 tokens have a different signature for AccrueInterest event. Here is an example from this page https://docs.compound.finance/v2/:

cCOMP	0x70e36f6BF80a52b3B46b3aF8e106CC0ed743E8e4 - has cashPrior in AccrueInterest
cUSDC	0x39AA39c021dfbaE8faC545936693aC917d5E7563 - doesn’t have cashPrior in AccrueInterest
