### PR TITLE
Add call events for L2 batches

### DIFF
--- a/dags/resources/stages/parse/table_definitions/arbitrum/SequencerInbox_call_addSequencerL2BatchFromOrigin.json
+++ b/dags/resources/stages/parse/table_definitions/arbitrum/SequencerInbox_call_addSequencerL2BatchFromOrigin.json
@@ -43,7 +43,7 @@
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "arbitrum",
         "schema": [
             {
                 "description": "",
@@ -77,6 +77,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_addSequencerL2BatchFromOrigin"
+        "table_name": "SequencerInbox_call_addSequencerL2BatchFromOrigin"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/arbitrum/SequencerInbox_call_addSequencerL2BatchFromOrigin.json
+++ b/dags/resources/stages/parse/table_definitions/arbitrum/SequencerInbox_call_addSequencerL2BatchFromOrigin.json
@@ -1,0 +1,82 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "sequenceNumber",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "afterDelayedMessagesRead",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "contract IGasRefunder",
+                    "name": "gasRefunder",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "prevMessageCount",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "newMessageCount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "addSequencerL2BatchFromOrigin",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0xd03bfe2ce83632f4e618a97299cc91b1335bb2d9",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "sequenceNumber",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "data",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "afterDelayedMessagesRead",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "gasRefunder",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "prevMessageCount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newMessageCount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_addSequencerL2BatchFromOrigin"
+    }
+}


### PR DESCRIPTION
## What?
Ecosystem team is in the process of upgrading the Chain Paradise feature, among others with Financial Analysis data that includes chain revenue calculations. To do the calculation for Arbitrum, we are trying to match [this query](https://dune.com/queries/1611505/2672828) on Dune and one of the tables there that we currently don't have is call events for L2 batches called `addSequencerL2BatchFromOrigin`.

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) on Arbitrum Sequencer Inbox's implementation contract (`0xd03bfe2ce83632f4e618a97299cc91b1335bb2d9`) to get this table definition file.