### PR TITLE
Add back the two sudoswap v2 pool creation events.

### DIFF
--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_event_NewERC1155Pair.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_event_NewERC1155Pair.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "poolAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "initialBalance",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NewERC1155Pair",
+            "type": "event"
+        },
+        "contract_address": "0xa020d57ab0448ef74115c112d18a9c231cc86000",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "sudoswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "poolAddress",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "initialBalance",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "LSSVMPairFactoryV2_event_NewERC1155Pair"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_event_NewERC721Pair.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_event_NewERC721Pair.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "poolAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256[]",
+                    "name": "initialIds",
+                    "type": "uint256[]"
+                }
+            ],
+            "name": "NewERC721Pair",
+            "type": "event"
+        },
+        "contract_address": "0xa020d57ab0448ef74115c112d18a9c231cc86000",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "sudoswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "poolAddress",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "initialIds",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "LSSVMPairFactoryV2_event_NewERC721Pair"
+    }
+}


### PR DESCRIPTION
## What?
Add support for sudoswap v2 pool creation events. Recover the files that should be merged in a previous [PR](https://github.com/blockchain-etl/ethereum-etl-airflow/pull/566).
