### PR TITLE
add more sudoswap v2 calls

### DIFF
--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC1155ERC20.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC1155ERC20.json
@@ -1,0 +1,152 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "contract ERC20",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract IERC1155",
+                            "name": "nft",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract ICurve",
+                            "name": "bondingCurve",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address payable",
+                            "name": "assetRecipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "enum LSSVMPair.PoolType",
+                            "name": "poolType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint128",
+                            "name": "delta",
+                            "type": "uint128"
+                        },
+                        {
+                            "internalType": "uint96",
+                            "name": "fee",
+                            "type": "uint96"
+                        },
+                        {
+                            "internalType": "uint128",
+                            "name": "spotPrice",
+                            "type": "uint128"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "nftId",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "initialNFTBalance",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "initialTokenBalance",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct LSSVMPairFactory.CreateERC1155ERC20PairParams",
+                    "name": "params",
+                    "type": "tuple"
+                }
+            ],
+            "name": "createPairERC1155ERC20",
+            "outputs": [
+                {
+                    "internalType": "contract LSSVMPairERC1155ERC20",
+                    "name": "pair",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0xa020d57ab0448ef74115c112d18a9c231cc86000",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "sudoswap",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "token",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "nft",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "bondingCurve",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "assetRecipient",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "poolType",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "delta",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "spotPrice",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "nftId",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "initialNFTBalance",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "initialTokenBalance",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "params",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "LSSVMPairFactoryV2_call_createPairERC1155ERC20"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC1155ETH.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC1155ETH.json
@@ -1,0 +1,118 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "contract IERC1155",
+                    "name": "_nft",
+                    "type": "address"
+                },
+                {
+                    "internalType": "contract ICurve",
+                    "name": "_bondingCurve",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address payable",
+                    "name": "_assetRecipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "enum LSSVMPair.PoolType",
+                    "name": "_poolType",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint128",
+                    "name": "_delta",
+                    "type": "uint128"
+                },
+                {
+                    "internalType": "uint96",
+                    "name": "_fee",
+                    "type": "uint96"
+                },
+                {
+                    "internalType": "uint128",
+                    "name": "_spotPrice",
+                    "type": "uint128"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_nftId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_initialNFTBalance",
+                    "type": "uint256"
+                }
+            ],
+            "name": "createPairERC1155ETH",
+            "outputs": [
+                {
+                    "internalType": "contract LSSVMPairERC1155ETH",
+                    "name": "pair",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0xa020d57ab0448ef74115c112d18a9c231cc86000",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "sudoswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "_nft",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_bondingCurve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_assetRecipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_poolType",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_delta",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_fee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_spotPrice",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_nftId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_initialNFTBalance",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "LSSVMPairFactoryV2_call_createPairERC1155ETH"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC721ERC20.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC721ERC20.json
@@ -1,0 +1,152 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "contract ERC20",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract IERC721",
+                            "name": "nft",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract ICurve",
+                            "name": "bondingCurve",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address payable",
+                            "name": "assetRecipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "enum LSSVMPair.PoolType",
+                            "name": "poolType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint128",
+                            "name": "delta",
+                            "type": "uint128"
+                        },
+                        {
+                            "internalType": "uint96",
+                            "name": "fee",
+                            "type": "uint96"
+                        },
+                        {
+                            "internalType": "uint128",
+                            "name": "spotPrice",
+                            "type": "uint128"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "propertyChecker",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256[]",
+                            "name": "initialNFTIDs",
+                            "type": "uint256[]"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "initialTokenBalance",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct LSSVMPairFactory.CreateERC721ERC20PairParams",
+                    "name": "params",
+                    "type": "tuple"
+                }
+            ],
+            "name": "createPairERC721ERC20",
+            "outputs": [
+                {
+                    "internalType": "contract LSSVMPairERC721ERC20",
+                    "name": "pair",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0xa020d57ab0448ef74115c112d18a9c231cc86000",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "sudoswap",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "token",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "nft",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "bondingCurve",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "assetRecipient",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "poolType",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "delta",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fee",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "spotPrice",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "propertyChecker",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "initialNFTIDs",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "initialTokenBalance",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "params",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "LSSVMPairFactoryV2_call_createPairERC721ERC20"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC721ETH.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC721ETH.json
@@ -1,0 +1,118 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "contract IERC721",
+                    "name": "_nft",
+                    "type": "address"
+                },
+                {
+                    "internalType": "contract ICurve",
+                    "name": "_bondingCurve",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address payable",
+                    "name": "_assetRecipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "enum LSSVMPair.PoolType",
+                    "name": "_poolType",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint128",
+                    "name": "_delta",
+                    "type": "uint128"
+                },
+                {
+                    "internalType": "uint96",
+                    "name": "_fee",
+                    "type": "uint96"
+                },
+                {
+                    "internalType": "uint128",
+                    "name": "_spotPrice",
+                    "type": "uint128"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_propertyChecker",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256[]",
+                    "name": "_initialNFTIDs",
+                    "type": "uint256[]"
+                }
+            ],
+            "name": "createPairERC721ETH",
+            "outputs": [
+                {
+                    "internalType": "contract LSSVMPairERC721ETH",
+                    "name": "pair",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0xa020d57ab0448ef74115c112d18a9c231cc86000",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "sudoswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "_nft",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_bondingCurve",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_assetRecipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_poolType",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_delta",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_fee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_spotPrice",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_propertyChecker",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_initialNFTIDs",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "LSSVMPairFactoryV2_call_createPairERC721ETH"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairV2ERC1155ETH_call_swapNFTsForToken.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairV2ERC1155ETH_call_swapNFTsForToken.json
@@ -1,0 +1,78 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint256[]",
+                    "name": "numNFTs",
+                    "type": "uint256[]"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "minExpectedTokenOutput",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address payable",
+                    "name": "tokenRecipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "isRouter",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "address",
+                    "name": "routerCaller",
+                    "type": "address"
+                }
+            ],
+            "name": "swapNFTsForToken",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "outputAmount",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT poolAddress FROM ref('LSSVMPairFactoryV2_event_NewERC1155Pair')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "sudoswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "numNFTs",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "minExpectedTokenOutput",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenRecipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "isRouter",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "routerCaller",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "LSSVMPairV2ERC1155ETH_call_swapNFTsForToken"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairV2ERC1155ETH_call_swapTokenForSpecificNFTs.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairV2ERC1155ETH_call_swapTokenForSpecificNFTs.json
@@ -73,6 +73,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "LSSVMPairV2ERC1155ETH_swapTokenForSpecificNFTs"
+        "table_name": "LSSVMPairV2ERC1155ETH_call_swapTokenForSpecificNFTs"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairV2ERC721ERC20_call_swapNFTsForToken.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairV2ERC721ERC20_call_swapNFTsForToken.json
@@ -1,0 +1,78 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint256[]",
+                    "name": "nftIds",
+                    "type": "uint256[]"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "minExpectedTokenOutput",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address payable",
+                    "name": "tokenRecipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "isRouter",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "address",
+                    "name": "routerCaller",
+                    "type": "address"
+                }
+            ],
+            "name": "swapNFTsForToken",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "outputAmount",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT poolAddress FROM ref('LSSVMPairFactoryV2_event_NewERC721Pair')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "sudoswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "nftIds",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "minExpectedTokenOutput",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenRecipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "isRouter",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "routerCaller",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "LSSVMPairV2ERC721ERC20_call_swapNFTsForToken"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairV2ERC721ERC20_call_swapTokenForSpecificNFTs.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairV2ERC721ERC20_call_swapTokenForSpecificNFTs.json
@@ -4,17 +4,17 @@
             "inputs": [
                 {
                     "internalType": "uint256[]",
-                    "name": "numNFTs",
+                    "name": "nftIds",
                     "type": "uint256[]"
                 },
                 {
                     "internalType": "uint256",
-                    "name": "minExpectedTokenOutput",
+                    "name": "maxExpectedTokenInput",
                     "type": "uint256"
                 },
                 {
-                    "internalType": "address payable",
-                    "name": "tokenRecipient",
+                    "internalType": "address",
+                    "name": "nftRecipient",
                     "type": "address"
                 },
                 {
@@ -28,18 +28,18 @@
                     "type": "address"
                 }
             ],
-            "name": "swapNFTsForToken",
+            "name": "swapTokenForSpecificNFTs",
             "outputs": [
                 {
                     "internalType": "uint256",
-                    "name": "outputAmount",
+                    "name": "",
                     "type": "uint256"
                 }
             ],
-            "stateMutability": "nonpayable",
+            "stateMutability": "payable",
             "type": "function"
         },
-        "contract_address": "SELECT poolAddress FROM ref('LSSVMPairFactoryV2_event_NewERC1155Pair')",
+        "contract_address": "SELECT poolAddress FROM ref('LSSVMPairFactoryV2_event_NewERC721Pair')",
         "field_mapping": {},
         "type": "trace"
     },
@@ -48,17 +48,17 @@
         "schema": [
             {
                 "description": "",
-                "name": "numNFTs",
+                "name": "nftIds",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "minExpectedTokenOutput",
+                "name": "maxExpectedTokenInput",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "tokenRecipient",
+                "name": "nftRecipient",
                 "type": "STRING"
             },
             {
@@ -73,6 +73,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "LSSVMPairV2ERC1155ETH_swapNFTsForToken"
+        "table_name": "LSSVMPairV2ERC721ERC20_call_swapTokenForSpecificNFTs"
     }
 }


### PR DESCRIPTION
## What?
add support for sudoswap v2 pair and factory contract calls

## How? 
used [abi-parser](https://contract-parser.d5.ai/)

## Related PRs (optional)
rename a couple of tables from PR #567 wherein i forgot to specify the action ('_call_'). not essential - just for others' benefit

