### PR TITLE
switch to nansen decoder to fix struct parsing issue

### DIFF
--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC1155ERC20.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC1155ERC20.json
@@ -85,65 +85,8 @@
         "schema": [
             {
                 "description": "",
-                "fields": [
-                    {
-                        "description": "",
-                        "name": "token",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "nft",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "bondingCurve",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "assetRecipient",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "poolType",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "delta",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "fee",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "spotPrice",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "nftId",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "initialNFTBalance",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "initialTokenBalance",
-                        "type": "STRING"
-                    }
-                ],
                 "name": "params",
-                "type": "RECORD"
+                "type": "STRING"
             }
         ],
         "table_description": "",

--- a/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC721ERC20.json
+++ b/dags/resources/stages/parse/table_definitions/sudoswap/LSSVMPairFactoryV2_call_createPairERC721ERC20.json
@@ -85,65 +85,8 @@
         "schema": [
             {
                 "description": "",
-                "fields": [
-                    {
-                        "description": "",
-                        "name": "token",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "nft",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "bondingCurve",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "assetRecipient",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "poolType",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "delta",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "fee",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "spotPrice",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "propertyChecker",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "initialNFTIDs",
-                        "type": "STRING"
-                    },
-                    {
-                        "description": "",
-                        "name": "initialTokenBalance",
-                        "type": "STRING"
-                    }
-                ],
                 "name": "params",
-                "type": "RECORD"
+                "type": "STRING"
             }
         ],
         "table_description": "",


### PR DESCRIPTION
## What?
Data inside the params struct is currently not parsing for LSSVMPairFactoryV2_call_createPairERC1155ERC20 and LSSVMPairFactoryV2_call_createPairERC721ERC20. Initially I used https://contract-parser.d5.ai/ but now resubmitting these function calls parsed with nansen decoder

## How? 
I used [Nansen abi parser](https://nansen-contract-parser-prod.web.app/)

## Related PRs
PR #569
