### PR TITLE
Blur V2  events and calls

### DIFF
--- a/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_buyToBorrowV2.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_buyToBorrowV2.json
@@ -1,0 +1,223 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "lender",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract ERC721",
+                            "name": "collection",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "minAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "maxAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "auctionDuration",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "salt",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "expirationTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "rate",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "oracle",
+                            "type": "address"
+                        }
+                    ],
+                    "internalType": "struct LoanOffer",
+                    "name": "offer",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "loanAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "collection",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "listingsRoot",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "numberOfListings",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "expirationTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "enum AssetType",
+                                    "name": "assetType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "address",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint16",
+                                            "name": "rate",
+                                            "type": "uint16"
+                                        }
+                                    ],
+                                    "internalType": "struct FeeRate",
+                                    "name": "makerFee",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Order",
+                            "name": "order",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "index",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "tokenId",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "price",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Listing",
+                            "name": "listing",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes32[]",
+                            "name": "proof",
+                            "type": "bytes32[]"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "oracleSignature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct AskExecutionV2",
+                    "name": "execution",
+                    "type": "tuple"
+                }
+            ],
+            "name": "buyToBorrowV2",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "lienId",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0xb258ca5559b11cd702f363796522b04d7722ea56",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "offer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "signature",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "loanAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "execution",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_buyToBorrowV2"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_buyToBorrowV2.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_buyToBorrowV2.json
@@ -189,12 +189,12 @@
             "stateMutability": "nonpayable",
             "type": "function"
         },
-        "contract_address": "0xb258ca5559b11cd702f363796522b04d7722ea56",
+        "contract_address": "0x29469395eaf6f95920e59f858042f0e28d98a20b",
         "field_mapping": {},
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "blur",
         "schema": [
             {
                 "description": "",
@@ -218,6 +218,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_buyToBorrowV2"
+        "table_name": "BlendV2_call_buyToBorrowV2"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_buyToBorrowV2ETH.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_buyToBorrowV2ETH.json
@@ -1,0 +1,223 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "lender",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract ERC721",
+                            "name": "collection",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "minAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "maxAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "auctionDuration",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "salt",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "expirationTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "rate",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "oracle",
+                            "type": "address"
+                        }
+                    ],
+                    "internalType": "struct LoanOffer",
+                    "name": "offer",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "loanAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "collection",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "listingsRoot",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "numberOfListings",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "expirationTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "enum AssetType",
+                                    "name": "assetType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "address",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint16",
+                                            "name": "rate",
+                                            "type": "uint16"
+                                        }
+                                    ],
+                                    "internalType": "struct FeeRate",
+                                    "name": "makerFee",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Order",
+                            "name": "order",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "index",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "tokenId",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "price",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Listing",
+                            "name": "listing",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes32[]",
+                            "name": "proof",
+                            "type": "bytes32[]"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "oracleSignature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct AskExecutionV2",
+                    "name": "execution",
+                    "type": "tuple"
+                }
+            ],
+            "name": "buyToBorrowV2ETH",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "lienId",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0xb258ca5559b11cd702f363796522b04d7722ea56",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "offer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "signature",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "loanAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "execution",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_buyToBorrowV2ETH"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_buyToBorrowV2ETH.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_buyToBorrowV2ETH.json
@@ -189,12 +189,12 @@
             "stateMutability": "payable",
             "type": "function"
         },
-        "contract_address": "0xb258ca5559b11cd702f363796522b04d7722ea56",
+        "contract_address": "0x29469395eaf6f95920e59f858042f0e28d98a20b",
         "field_mapping": {},
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "blur",
         "schema": [
             {
                 "description": "",
@@ -218,6 +218,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_buyToBorrowV2ETH"
+        "table_name": "BlendV2_call_buyToBorrowV2ETH"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_takeBidV2.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_takeBidV2.json
@@ -1,0 +1,202 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "lender",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "borrower",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "contract ERC721",
+                            "name": "collection",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "tokenId",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "startTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "rate",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "auctionStartBlock",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "auctionDuration",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct Lien",
+                    "name": "lien",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "lienId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "collection",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "listingsRoot",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "numberOfListings",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "expirationTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "enum AssetType",
+                                    "name": "assetType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "address",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint16",
+                                            "name": "rate",
+                                            "type": "uint16"
+                                        }
+                                    ],
+                                    "internalType": "struct FeeRate",
+                                    "name": "makerFee",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Order",
+                            "name": "order",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "index",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "tokenId",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "price",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Listing",
+                            "name": "listing",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes32[]",
+                            "name": "proof",
+                            "type": "bytes32[]"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "oracleSignature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct BidExecutionV2",
+                    "name": "execution",
+                    "type": "tuple"
+                }
+            ],
+            "name": "takeBidV2",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0xb258ca5559b11cd702f363796522b04d7722ea56",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "lien",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "lienId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "execution",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_takeBidV2"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_takeBidV2.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlendV2_call_takeBidV2.json
@@ -173,12 +173,12 @@
             "stateMutability": "nonpayable",
             "type": "function"
         },
-        "contract_address": "0xb258ca5559b11cd702f363796522b04d7722ea56",
+        "contract_address": "0x29469395eaf6f95920e59f858042f0e28d98a20b",
         "field_mapping": {},
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "blur",
         "schema": [
             {
                 "description": "",
@@ -197,6 +197,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_takeBidV2"
+        "table_name": "BlendV2_call_takeBidV2"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_cancelTrades.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_cancelTrades.json
@@ -30,12 +30,12 @@
             "stateMutability": "nonpayable",
             "type": "function"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "blur",
         "schema": [
             {
                 "description": "",
@@ -44,6 +44,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_cancelTrades"
+        "table_name": "BlurExchangeV2_call_cancelTrades"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_cancelTrades.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_cancelTrades.json
@@ -1,0 +1,49 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "hash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "index",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct Cancel[]",
+                    "name": "cancels",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "cancelTrades",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "cancels",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_cancelTrades"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAsk.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAsk.json
@@ -1,0 +1,191 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "collection",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "listingsRoot",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "numberOfListings",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "expirationTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "enum AssetType",
+                                    "name": "assetType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "address",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint16",
+                                            "name": "rate",
+                                            "type": "uint16"
+                                        }
+                                    ],
+                                    "internalType": "struct FeeRate",
+                                    "name": "makerFee",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Order[]",
+                            "name": "orders",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "index",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32[]",
+                                    "name": "proof",
+                                    "type": "bytes32[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "index",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "price",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Listing",
+                                    "name": "listing",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Taker",
+                                    "name": "taker",
+                                    "type": "tuple"
+                                }
+                            ],
+                            "internalType": "struct Exchange[]",
+                            "name": "exchanges",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "recipient",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "rate",
+                                    "type": "uint16"
+                                }
+                            ],
+                            "internalType": "struct FeeRate",
+                            "name": "takerFee",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signatures",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "tokenRecipient",
+                            "type": "address"
+                        }
+                    ],
+                    "internalType": "struct TakeAsk",
+                    "name": "inputs",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "oracleSignature",
+                    "type": "bytes"
+                }
+            ],
+            "name": "takeAsk",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "inputs",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracleSignature",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_takeAsk"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAsk.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAsk.json
@@ -167,12 +167,12 @@
             "stateMutability": "payable",
             "type": "function"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "blur",
         "schema": [
             {
                 "description": "",
@@ -186,6 +186,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_takeAsk"
+        "table_name": "BlurExchangeV2_call_takeAsk"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskPool.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskPool.json
@@ -1,0 +1,201 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "collection",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "listingsRoot",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "numberOfListings",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "expirationTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "enum AssetType",
+                                    "name": "assetType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "address",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint16",
+                                            "name": "rate",
+                                            "type": "uint16"
+                                        }
+                                    ],
+                                    "internalType": "struct FeeRate",
+                                    "name": "makerFee",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Order[]",
+                            "name": "orders",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "index",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32[]",
+                                    "name": "proof",
+                                    "type": "bytes32[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "index",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "price",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Listing",
+                                    "name": "listing",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Taker",
+                                    "name": "taker",
+                                    "type": "tuple"
+                                }
+                            ],
+                            "internalType": "struct Exchange[]",
+                            "name": "exchanges",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "recipient",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "rate",
+                                    "type": "uint16"
+                                }
+                            ],
+                            "internalType": "struct FeeRate",
+                            "name": "takerFee",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signatures",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "tokenRecipient",
+                            "type": "address"
+                        }
+                    ],
+                    "internalType": "struct TakeAsk",
+                    "name": "inputs",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "oracleSignature",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amountToWithdraw",
+                    "type": "uint256"
+                }
+            ],
+            "name": "takeAskPool",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "inputs",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracleSignature",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountToWithdraw",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_takeAskPool"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskPool.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskPool.json
@@ -172,12 +172,12 @@
             "stateMutability": "payable",
             "type": "function"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "blur",
         "schema": [
             {
                 "description": "",
@@ -196,6 +196,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_takeAskPool"
+        "table_name": "BlurExchangeV2_call_takeAskPool"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskSingle.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskSingle.json
@@ -1,0 +1,191 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "collection",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "listingsRoot",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "numberOfListings",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "expirationTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "enum AssetType",
+                                    "name": "assetType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "address",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint16",
+                                            "name": "rate",
+                                            "type": "uint16"
+                                        }
+                                    ],
+                                    "internalType": "struct FeeRate",
+                                    "name": "makerFee",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Order",
+                            "name": "order",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "index",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32[]",
+                                    "name": "proof",
+                                    "type": "bytes32[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "index",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "price",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Listing",
+                                    "name": "listing",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Taker",
+                                    "name": "taker",
+                                    "type": "tuple"
+                                }
+                            ],
+                            "internalType": "struct Exchange",
+                            "name": "exchange",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "recipient",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "rate",
+                                    "type": "uint16"
+                                }
+                            ],
+                            "internalType": "struct FeeRate",
+                            "name": "takerFee",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "tokenRecipient",
+                            "type": "address"
+                        }
+                    ],
+                    "internalType": "struct TakeAskSingle",
+                    "name": "inputs",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "oracleSignature",
+                    "type": "bytes"
+                }
+            ],
+            "name": "takeAskSingle",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "inputs",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracleSignature",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_takeAskSingle"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskSingle.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskSingle.json
@@ -167,12 +167,12 @@
             "stateMutability": "payable",
             "type": "function"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "blur",
         "schema": [
             {
                 "description": "",
@@ -186,6 +186,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_takeAskSingle"
+        "table_name": "BlurExchangeV2_call_takeAskSingle"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskSinglePool.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskSinglePool.json
@@ -172,12 +172,12 @@
             "stateMutability": "payable",
             "type": "function"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "blur",
         "schema": [
             {
                 "description": "",
@@ -196,6 +196,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_takeAskSinglePool"
+        "table_name": "BlurExchangeV2_call_takeAskSinglePool"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskSinglePool.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeAskSinglePool.json
@@ -1,0 +1,201 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "collection",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "listingsRoot",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "numberOfListings",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "expirationTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "enum AssetType",
+                                    "name": "assetType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "address",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint16",
+                                            "name": "rate",
+                                            "type": "uint16"
+                                        }
+                                    ],
+                                    "internalType": "struct FeeRate",
+                                    "name": "makerFee",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Order",
+                            "name": "order",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "index",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32[]",
+                                    "name": "proof",
+                                    "type": "bytes32[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "index",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "price",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Listing",
+                                    "name": "listing",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Taker",
+                                    "name": "taker",
+                                    "type": "tuple"
+                                }
+                            ],
+                            "internalType": "struct Exchange",
+                            "name": "exchange",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "recipient",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "rate",
+                                    "type": "uint16"
+                                }
+                            ],
+                            "internalType": "struct FeeRate",
+                            "name": "takerFee",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "tokenRecipient",
+                            "type": "address"
+                        }
+                    ],
+                    "internalType": "struct TakeAskSingle",
+                    "name": "inputs",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "oracleSignature",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amountToWithdraw",
+                    "type": "uint256"
+                }
+            ],
+            "name": "takeAskSinglePool",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "inputs",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracleSignature",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountToWithdraw",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_takeAskSinglePool"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeBid.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeBid.json
@@ -1,0 +1,186 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "collection",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "listingsRoot",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "numberOfListings",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "expirationTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "enum AssetType",
+                                    "name": "assetType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "address",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint16",
+                                            "name": "rate",
+                                            "type": "uint16"
+                                        }
+                                    ],
+                                    "internalType": "struct FeeRate",
+                                    "name": "makerFee",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Order[]",
+                            "name": "orders",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "index",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32[]",
+                                    "name": "proof",
+                                    "type": "bytes32[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "index",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "price",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Listing",
+                                    "name": "listing",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Taker",
+                                    "name": "taker",
+                                    "type": "tuple"
+                                }
+                            ],
+                            "internalType": "struct Exchange[]",
+                            "name": "exchanges",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "recipient",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "rate",
+                                    "type": "uint16"
+                                }
+                            ],
+                            "internalType": "struct FeeRate",
+                            "name": "takerFee",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signatures",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct TakeBid",
+                    "name": "inputs",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "oracleSignature",
+                    "type": "bytes"
+                }
+            ],
+            "name": "takeBid",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "inputs",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracleSignature",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_takeBid"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeBid.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeBid.json
@@ -162,12 +162,12 @@
             "stateMutability": "nonpayable",
             "type": "function"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "blur",
         "schema": [
             {
                 "description": "",
@@ -181,6 +181,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_takeBid"
+        "table_name": "BlurExchangeV2_call_takeBid"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeBidSingle.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeBidSingle.json
@@ -1,0 +1,186 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "collection",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "listingsRoot",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "numberOfListings",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "expirationTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "enum AssetType",
+                                    "name": "assetType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "address",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint16",
+                                            "name": "rate",
+                                            "type": "uint16"
+                                        }
+                                    ],
+                                    "internalType": "struct FeeRate",
+                                    "name": "makerFee",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct Order",
+                            "name": "order",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "index",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32[]",
+                                    "name": "proof",
+                                    "type": "bytes32[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "index",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "price",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Listing",
+                                    "name": "listing",
+                                    "type": "tuple"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "tokenId",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "amount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct Taker",
+                                    "name": "taker",
+                                    "type": "tuple"
+                                }
+                            ],
+                            "internalType": "struct Exchange",
+                            "name": "exchange",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "recipient",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "rate",
+                                    "type": "uint16"
+                                }
+                            ],
+                            "internalType": "struct FeeRate",
+                            "name": "takerFee",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct TakeBidSingle",
+                    "name": "inputs",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "oracleSignature",
+                    "type": "bytes"
+                }
+            ],
+            "name": "takeBidSingle",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "inputs",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracleSignature",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_takeBidSingle"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeBidSingle.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_call_takeBidSingle.json
@@ -162,12 +162,12 @@
             "stateMutability": "nonpayable",
             "type": "function"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "blur",
         "schema": [
             {
                 "description": "",
@@ -181,6 +181,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_takeBidSingle"
+        "table_name": "BlurExchangeV2_call_takeBidSingle"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_CancelTrade.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_CancelTrade.json
@@ -31,7 +31,7 @@
             "name": "CancelTrade",
             "type": "event"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_CancelTrade.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_CancelTrade.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "hash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CancelTrade",
+            "type": "event"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "blur",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "hash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlurExchangeV2_event_CancelTrade"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution.json
@@ -124,7 +124,7 @@
             "name": "Execution",
             "type": "event"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution.json
@@ -1,0 +1,248 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "trader",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "id",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "collection",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "enum AssetType",
+                            "name": "assetType",
+                            "type": "uint8"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct Transfer",
+                    "name": "transfer",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "listingIndex",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "price",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint16",
+                            "name": "rate",
+                            "type": "uint16"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct FeeRate",
+                    "name": "makerFee",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "recipient",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "rate",
+                                    "type": "uint16"
+                                }
+                            ],
+                            "internalType": "struct FeeRate",
+                            "name": "protocolFee",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "recipient",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "rate",
+                                    "type": "uint16"
+                                }
+                            ],
+                            "internalType": "struct FeeRate",
+                            "name": "takerFee",
+                            "type": "tuple"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct Fees",
+                    "name": "fees",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "enum OrderType",
+                    "name": "orderType",
+                    "type": "uint8"
+                }
+            ],
+            "name": "Execution",
+            "type": "event"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "blur",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "trader",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "id",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "amount",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "collection",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "assetType",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "transfer",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "listingIndex",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "price",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "recipient",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "rate",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "makerFee",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "recipient",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "rate",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "protocolFee",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "recipient",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "rate",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "takerFee",
+                        "type": "RECORD"
+                    }
+                ],
+                "name": "fees",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "name": "orderType",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlurExchangeV2_event_Execution"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721MakerFeePacked.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721MakerFeePacked.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "tokenIdListingIndexTrader",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collectionPriceSide",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "makerFeeRecipientRate",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Execution721MakerFeePacked",
+            "type": "event"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "blur",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenIdListingIndexTrader",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collectionPriceSide",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "makerFeeRecipientRate",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlurExchangeV2_event_Execution721MakerFeePacked"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721MakerFeePacked.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721MakerFeePacked.json
@@ -31,7 +31,7 @@
             "name": "Execution721MakerFeePacked",
             "type": "event"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721Packed.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721Packed.json
@@ -25,7 +25,7 @@
             "name": "Execution721Packed",
             "type": "event"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721Packed.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721Packed.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "tokenIdListingIndexTrader",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collectionPriceSide",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Execution721Packed",
+            "type": "event"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "blur",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenIdListingIndexTrader",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collectionPriceSide",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlurExchangeV2_event_Execution721Packed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721TakerFeePacked.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721TakerFeePacked.json
@@ -31,7 +31,7 @@
             "name": "Execution721TakerFeePacked",
             "type": "event"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721TakerFeePacked.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Execution721TakerFeePacked.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "tokenIdListingIndexTrader",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collectionPriceSide",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "takerFeeRecipientRate",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Execution721TakerFeePacked",
+            "type": "event"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "blur",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenIdListingIndexTrader",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collectionPriceSide",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "takerFeeRecipientRate",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlurExchangeV2_event_Execution721TakerFeePacked"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_NewProtocolFee.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_NewProtocolFee.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint16",
+                    "name": "rate",
+                    "type": "uint16"
+                }
+            ],
+            "name": "NewProtocolFee",
+            "type": "event"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "blur",
+        "schema": [
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "rate",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlurExchangeV2_event_NewProtocolFee"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_NewProtocolFee.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_NewProtocolFee.json
@@ -19,7 +19,7 @@
             "name": "NewProtocolFee",
             "type": "event"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Upgraded.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Upgraded.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "Upgraded",
+            "type": "event"
+        },
+        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "blur",
+        "schema": [
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "BlurExchangeV2_event_Upgraded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Upgraded.json
+++ b/dags/resources/stages/parse/table_definitions/blur/BlurExchangeV2_event_Upgraded.json
@@ -13,7 +13,7 @@
             "name": "Upgraded",
             "type": "event"
         },
-        "contract_address": "0x5fa60726e62c50af45ff2f6280c468da438a7837",
+        "contract_address": "0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
## What?
- Add support for Blur v2 contract events and calls
- Add new Blend v2 calls (from the new v2 implementation)
-- no new Blend v2 events

## How? 
I used the [abi-parser](https://nansen-contract-parser-prod.web.app/)  tools to build the table definitions

## Related  (optional)
None

