### PR TITLE
Add state to parse DAG

### DIFF
--- a/dags/ethereumetl_airflow/build_parse_dag.py
+++ b/dags/ethereumetl_airflow/build_parse_dag.py
@@ -14,6 +14,7 @@ from google.cloud import bigquery
 from ethereumetl_airflow.bigquery_utils import share_dataset_all_users_read
 from ethereumetl_airflow.common import read_json_file, get_list_of_files
 from ethereumetl_airflow.parse.parse_dataset_folder_logic import parse_dataset_folder
+from ethereumetl_airflow.parse.parse_state_manager import ParseStateManager
 
 logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
@@ -23,6 +24,7 @@ dags_folder = os.environ.get('DAGS_FOLDER', '/home/airflow/gcs/dags')
 
 def build_parse_dag(
         dag_id,
+        output_bucket,
         dataset_folder,
         parse_destination_dataset_project_id,
         notification_emails=None,
@@ -76,6 +78,7 @@ def build_parse_dag(
                 source_project_id=SOURCE_PROJECT_ID,
                 source_dataset_name=SOURCE_DATASET_NAME,
                 destination_project_id=parse_destination_dataset_project_id,
+                parse_state_manager=ParseStateManager(dataset_name, output_bucket, 'parse/state'),
                 sqls_folder=os.path.join(dags_folder, 'resources/stages/parse/sqls'),
                 parse_all_partitions=parse_all_partitions
             )
@@ -89,7 +92,6 @@ def build_parse_dag(
         )
 
         return parsing_operator
-
 
     def create_share_dataset_task(dataset_name):
         def share_dataset_task(**kwargs):

--- a/dags/ethereumetl_airflow/parse/parse_dataset_folder_logic.py
+++ b/dags/ethereumetl_airflow/parse/parse_dataset_folder_logic.py
@@ -3,9 +3,11 @@ import os
 import time
 
 from ethereumetl_airflow.bigquery_utils import create_view
-from ethereumetl_airflow.common import get_list_of_files, read_json_file, read_file
+from ethereumetl_airflow.common import read_json_file, read_file
+from ethereumetl_airflow.parse.parse_state_manager import ParseStateManager
 from ethereumetl_airflow.parse.parse_table_definition_logic import parse, ref_regex, create_dataset, replace_refs
-from ethereumetl_airflow.parse.toposort import toposort_flatten
+from ethereumetl_airflow.parse.table_definition import TableDefinitionFileType
+from ethereumetl_airflow.parse.table_definition_reader import read_table_definitions, toposort_and_read_table_definition_states
 
 
 def parse_dataset_folder(
@@ -15,84 +17,63 @@ def parse_dataset_folder(
         source_project_id,
         source_dataset_name,
         destination_project_id,
+        parse_state_manager: ParseStateManager,
         sqls_folder,
         parse_all_partitions,
         time_func=time.time
 ):
     logging.info(f'Parsing dataset folder {dataset_folder}')
-    files = get_list_of_files(dataset_folder, ['*.json', '*.sql'])
-    logging.info(files)
 
-    topologically_sorted_files = topologically_sort_files(files)
-    logging.info(f'Topologically sorted files: {topologically_sorted_files}')
+    table_definitions = read_table_definitions(dataset_folder)
 
-    for index, file in enumerate(topologically_sorted_files):
-        logging.info(f'Parsing file {index} out of {len(topologically_sorted_files)}: {file}')
-        if '.json' in file:
-            table_definition = read_json_file(file)
+    table_definition_states = toposort_and_read_table_definition_states(table_definitions, parse_state_manager)
+
+    for table_definition_state in table_definition_states:
+        logging.info(f'{table_definition_state.table_definition.filepath}: is_updated_or_dependencies_updated: {table_definition_state.is_updated_or_dependencies_updated}')
+
+    updated_table_definitions = [tds.table_definition for tds in table_definition_states if tds.is_updated_or_dependencies_updated]
+
+    # Prevents accidentally running full refresh for many tables caused by bugs
+    max_num_updated_table_definitions = 50
+    if len(updated_table_definitions) > max_num_updated_table_definitions:
+        raise ValueError(f'More than {max_num_updated_table_definitions} will be fully refreshed. Please make sure not more than {max_num_updated_table_definitions} are updated')
+
+    for index, table_definition_state in enumerate(table_definition_states):
+        table_definition = table_definition_state.table_definition
+        logging.info(f'Parsing file {index} out of {len(table_definition_states)}: {table_definition.filepath}')
+        if table_definition.filetype == TableDefinitionFileType.JSON:
+            table_definition_content = read_json_file(table_definition.filepath)
             parse(
                 bigquery_client,
-                table_definition,
+                table_definition_content,
                 ds,
                 source_project_id,
                 source_dataset_name,
                 destination_project_id,
                 sqls_folder,
-                parse_all_partitions,
+                parse_all_partitions if parse_all_partitions is not None else table_definition_state.is_updated_or_dependencies_updated,
                 time_func=time_func
             )
-        elif '.sql' in file:
-            base_name = os.path.basename(file)
-            view_name = os.path.splitext(base_name)[0]
+        elif table_definition.filetype == TableDefinitionFileType.SQL:
+            view_name = table_definition.table_name
             dest_table_name = view_name
 
             dataset_name = os.path.basename(dataset_folder)
             dataset_name = 'ethereum_' + dataset_name
 
             dest_table_ref = create_dataset(bigquery_client, dataset_name, destination_project_id).table(dest_table_name)
-            sql = read_file(file)
+            sql = read_file(table_definition.filepath)
             sql = replace_refs(sql, ref_regex, destination_project_id, dataset_name)
 
             create_view(bigquery_client, sql, dest_table_ref)
         else:
-            raise ValueError(f'Unrecognized file type: {file}')
+            raise ValueError(f'Unrecognized file type: {table_definition.filepath}')
 
+    for table_definition_state in table_definition_states:
+        if table_definition_state.is_updated_or_dependencies_updated:
+            table_definition = table_definition_state.table_definition
+            logging.info(f'Updating content hash for {table_definition.table_name}: {table_definition.content_hash}')
+            parse_state_manager.set_content_hash(table_definition.table_name, table_definition.content_hash)
 
-def topologically_sort_files(files):
-    table_name_to_file_map = {}
-    dependencies = {}
+    parse_state_manager.persist_state()
 
-    for file in files:
-        ref_dependencies = None
-        if '.json' in file:
-            table_definition = read_json_file(file)
-            contract_address = table_definition['parser']['contract_address']
-            ref_dependencies = ref_regex.findall(contract_address) if contract_address is not None else None
-        elif '.sql' in file:
-            sql = read_file(file)
-            ref_dependencies = ref_regex.findall(sql) if sql is not None else None
-
-        table_name = get_table_name_from_file_name(file)
-
-        dependencies[table_name] = set(ref_dependencies) if ref_dependencies is not None else set()
-        table_name_to_file_map[table_name] = file
-
-    validate_dependencies(dependencies, table_name_to_file_map.keys())
-    logging.info(f'Table definition dependencies: {dependencies}')
-
-    # TODO: Use toposort() instead of toposort_flatten() so that independent tables could be run in parallel
-    sorted_tables = list(toposort_flatten(dependencies))
-
-    topologically_sorted_files = [table_name_to_file_map[table_name] for table_name in sorted_tables]
-    return topologically_sorted_files
-
-
-def validate_dependencies(dependencies, table_names):
-    for deps in dependencies.values():
-        for dep_table_name in deps:
-            if dep_table_name not in table_names:
-                raise ValueError(f'Dependency {dep_table_name} not found. Check ref() in table definitions')
-
-
-def get_table_name_from_file_name(file_name):
-    return file_name.split('/')[-1].replace('.json', '').replace('.sql', '')

--- a/dags/ethereumetl_airflow/parse/parse_state_manager.py
+++ b/dags/ethereumetl_airflow/parse/parse_state_manager.py
@@ -1,0 +1,50 @@
+import json
+import logging
+
+from google.cloud.exceptions import NotFound
+from google.cloud import storage
+
+
+class ParseStateManager:
+    def __init__(self, dataset_name, state_bucket, bucket_path):
+        self.dataset_name = dataset_name
+        self.state_bucket = state_bucket
+        self.bucket_path = bucket_path
+
+        self.storage_client = storage.Client()
+
+        state_file = self._download_state_file()
+        if state_file:
+            self.state = json.loads(state_file)
+        else:
+            self.state = {}
+
+    def get_content_hash(self, table_name):
+        content_hash = self.state.get(table_name)
+        if not content_hash:
+            content_hash = ''
+        return content_hash
+
+    def set_content_hash(self, table_name, new_hash):
+        self.state[table_name] = new_hash
+
+    def persist_state(self):
+        bucket = self.storage_client.get_bucket(self.state_bucket)
+        blob = bucket.blob(self._build_state_file_name())
+        state_str = json.dumps(self.state)
+        logging.info(f'Persisting parse state: {state_str}')
+        blob.upload_from_string(state_str)
+
+    def _build_state_file_name(self):
+        return f'{self.bucket_path}/{self.dataset_name}/state.json'
+
+    def _download_state_file(self):
+        bucket = self.storage_client.get_bucket(self.state_bucket)
+
+        blob = bucket.blob(self._build_state_file_name())
+
+        try:
+            content = blob.download_as_text()
+            return content
+        except NotFound:
+            return None

--- a/dags/ethereumetl_airflow/parse/parse_table_definition_logic.py
+++ b/dags/ethereumetl_airflow/parse/parse_table_definition_logic.py
@@ -45,14 +45,13 @@ def parse(
         sqls_folder=sqls_folder
     )
 
-    dataset = create_dataset(bigquery_client, dataset_name, internal_project_id)
     table_name = table_definition['table']['table_name']
     history_table_name = table_name + '_history'
+
     if parse_all_partitions is None:
-        history_table_ref = dataset.table(history_table_name)
-        history_table_exists = does_table_exist(bigquery_client, history_table_ref)
-        parse_all_partitions = not history_table_exists
-        logging.info('parse_all_partitions is set to {}'.format(str(parse_all_partitions)))
+        raise ValueError('parse_all_partitions cannot be None')
+
+    logging.info('parse_all_partitions is set to {}'.format(str(parse_all_partitions)))
 
     create_or_update_history_table(
         bigquery_client=bigquery_client,

--- a/dags/ethereumetl_airflow/parse/table_definition.py
+++ b/dags/ethereumetl_airflow/parse/table_definition.py
@@ -1,0 +1,24 @@
+class TableDefinitionFileType:
+    JSON = 'json'
+    SQL = 'sql'
+
+
+class TableDefinition:
+    def __init__(
+            self,
+            table_name,
+            filetype: TableDefinitionFileType,
+            filepath,
+            content_hash,
+            ref_dependencies,
+            dependencies
+    ):
+        self.table_name = table_name
+        self.filetype = filetype
+        self.filepath = filepath
+        self.ref_dependencies = ref_dependencies
+        self.content_hash = content_hash
+        self.dependencies = dependencies
+
+
+

--- a/dags/ethereumetl_airflow/parse/table_definition_reader.py
+++ b/dags/ethereumetl_airflow/parse/table_definition_reader.py
@@ -1,0 +1,118 @@
+import hashlib
+import json
+from typing import List
+
+from ethereumetl_airflow.common import get_list_of_files, read_file
+from ethereumetl_airflow.parse.parse_state_manager import ParseStateManager
+from ethereumetl_airflow.parse.parse_table_definition_logic import ref_regex
+from ethereumetl_airflow.parse.table_definition import TableDefinition, TableDefinitionFileType
+from ethereumetl_airflow.parse.table_definition_state import TableDefinitionState
+from ethereumetl_airflow.parse.toposort import toposort_flatten
+
+
+# Reads table definitions from a dataset_folder and returns a list of TableDefinition objects
+def read_table_definitions(dataset_folder: str) -> List[TableDefinition]:
+    file_paths = get_list_of_files(dataset_folder, ['*.json', '*.sql'])
+
+    table_definitions_dict = {}
+    for file_path in file_paths:
+        table_name = extract_table_name(file_path)
+
+        if table_definitions_dict.get(table_name):
+            raise ValueError(f"Duplicate table name {table_name}")
+
+        file_content = read_file(file_path)
+        ref_dependencies, filetype = extract_file_dependencies_and_type(file_path, file_content)
+
+        table_definition = TableDefinition(
+            table_name=table_name,
+            filetype=filetype,
+            filepath=file_path,
+            content_hash=calculate_content_hash(file_content),
+            ref_dependencies=ref_dependencies,
+            dependencies=None
+        )
+        table_definitions_dict[table_name] = table_definition
+
+    validate_ref_dependencies(table_definitions_dict)
+    set_table_dependencies(table_definitions_dict)
+
+    return list(table_definitions_dict.values())
+
+
+# Reads and returns the states of given table definitions
+def toposort_and_read_table_definition_states(
+        table_definitions: List[TableDefinition],
+        parse_state_manager: ParseStateManager
+) -> List[TableDefinitionState]:
+    states = {}
+    topologically_sorted_definitions = sort_table_definitions_topologically(table_definitions)
+
+    for table_definition in topologically_sorted_definitions:
+        previous_hash = parse_state_manager.get_content_hash(table_definition.table_name)
+        current_hash = table_definition.content_hash
+        is_updated = previous_hash != current_hash
+
+        assert all(states.get(parent.table_name) is not None for parent in table_definition.dependencies)
+        is_dependencies_updated = any(states[parent.table_name].is_updated_or_dependencies_updated for parent in table_definition.dependencies)
+        is_updated_or_dependencies_updated = is_updated or is_dependencies_updated
+        state = TableDefinitionState(table_definition, is_updated_or_dependencies_updated)
+        states[table_definition.table_name] = state
+
+    return [states[table_definition.table_name] for table_definition in topologically_sorted_definitions]
+
+
+# Extracts table name from file path
+def extract_table_name(file_path):
+    return file_path.split('/')[-1].replace('.json', '').replace('.sql', '')
+
+
+# Extracts dependencies and file type from file path and content
+def extract_file_dependencies_and_type(file_path, file_content):
+    if '.json' in file_path:
+        filetype = TableDefinitionFileType.JSON
+        parsed_content = json.loads(file_content)
+        contract_address = parsed_content['parser']['contract_address']
+        ref_dependencies = ref_regex.findall(contract_address) if contract_address is not None else []
+    elif '.sql' in file_path:
+        filetype = TableDefinitionFileType.SQL
+        ref_dependencies = ref_regex.findall(file_content) if file_content is not None else []
+    else:
+        raise ValueError(f'Unknown file type {file_path}')
+    return ref_dependencies, filetype
+
+
+def validate_ref_dependencies(table_definitions_dict):
+    for table_definition in table_definitions_dict.values():
+        for dep_table_name in (table_definition.ref_dependencies or []):
+            if dep_table_name not in table_definitions_dict:
+                raise ValueError(f'Dependency {dep_table_name} not found. Check ref() in table definitions')
+
+
+# Sets dependencies for each table in table_definitions_dict
+def set_table_dependencies(table_definitions_dict):
+    for table_definition in table_definitions_dict.values():
+        table_definition.dependencies = [table_definitions_dict[d] for d in table_definition.ref_dependencies]
+
+
+# Returns a list of TableDefinition objects sorted topologically
+def sort_table_definitions_topologically(table_definitions: List[TableDefinition]) -> List[TableDefinition]:
+    table_name_to_definition_map = {}
+    dependencies = {}
+
+    for table_definition in table_definitions:
+        table_dependencies = [d.table_name for d in table_definition.dependencies] if table_definition.dependencies else set()
+        dependencies[table_definition.table_name] = table_dependencies
+        table_name_to_definition_map[table_definition.table_name] = table_definition
+
+    sorted_table_names = list(toposort_flatten(dependencies))
+    return [table_name_to_definition_map[table_name] for table_name in sorted_table_names]
+
+
+# Calculates and returns hash of the content
+# Can be calculated from contents of a file in command line on MacOS:
+# > shasum -a 256 <path_to_file>
+def calculate_content_hash(content):
+    hash_object = hashlib.sha256()
+    hash_object.update(content.encode())
+    return hash_object.hexdigest()

--- a/dags/ethereumetl_airflow/parse/table_definition_state.py
+++ b/dags/ethereumetl_airflow/parse/table_definition_state.py
@@ -1,0 +1,10 @@
+class TableDefinitionState:
+    def __init__(
+            self,
+            table_definition,
+            is_updated_or_dependencies_updated
+    ):
+        self.table_definition = table_definition
+        self.is_updated_or_dependencies_updated = is_updated_or_dependencies_updated
+
+

--- a/dags/ethereumetl_airflow/variables.py
+++ b/dags/ethereumetl_airflow/variables.py
@@ -93,6 +93,7 @@ def read_amend_dag_vars(var_prefix, **kwargs):
 
 def read_parse_dag_vars(var_prefix, **kwargs):
     vars = {
+        'output_bucket': read_var('output_bucket', var_prefix, True, **kwargs),
         'parse_destination_dataset_project_id': read_var('parse_destination_dataset_project_id', var_prefix, True, **kwargs),
         'schedule_interval': read_var('schedule_interval', var_prefix, True, **kwargs),
         'parse_all_partitions': parse_bool(read_var('parse_all_partitions', var_prefix, False), default=None),

--- a/tests/ethereumetl_airflow/mock_parse_state_manager.py
+++ b/tests/ethereumetl_airflow/mock_parse_state_manager.py
@@ -1,0 +1,28 @@
+import os.path
+
+from ethereumetl_airflow.build_verify_streaming_dag import read_file
+from ethereumetl_airflow.parse.table_definition_reader import calculate_content_hash
+
+
+class MockParseStateManager:
+    def __init__(self, dataset_folder, updated_table_names=()):
+        self.dataset_folder = dataset_folder
+        self.updated_table_names = updated_table_names
+
+    def get_content_hash(self, table_name):
+        if table_name in self.updated_table_names:
+            return ''
+
+        try:
+            content = read_file(os.path.join(self.dataset_folder, f'{table_name}.json'))
+            return calculate_content_hash(content)
+        except FileNotFoundError:
+            content = read_file(os.path.join(self.dataset_folder, f'{table_name}.sql'))
+            return calculate_content_hash(content)
+
+
+    def set_content_hash(self, table_name, new_hash):
+        pass
+
+    def persist_state(self):
+        pass

--- a/tests/ethereumetl_airflow/test_table_definition_reader.py
+++ b/tests/ethereumetl_airflow/test_table_definition_reader.py
@@ -1,0 +1,33 @@
+import logging
+import os
+
+import pytest
+
+from ethereumetl_airflow.parse.table_definition_reader import read_table_definitions, toposort_and_read_table_definition_states
+from tests.ethereumetl_airflow.mock_parse_state_manager import MockParseStateManager
+
+table_definitions_folder = 'dags/resources/stages/parse/table_definitions'
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s [%(levelname)s] - %(message)s')
+
+@pytest.mark.parametrize("dataset_folder", [
+    ('chainlink'),
+])
+def test_read_table_definition_states(dataset_folder):
+    full_dataset_folder = os.path.join(table_definitions_folder, dataset_folder)
+
+    parse_state_manager = MockParseStateManager(full_dataset_folder, updated_table_names=('view_AccessControlledOffchainAggregator_info'))
+    # parse_state_manager = ParseStateManager(dataset_folder, 'ethereum-etl-dev-2', 'parse/state')
+
+    table_definitions = read_table_definitions(full_dataset_folder)
+
+    table_definition_states = toposort_and_read_table_definition_states(table_definitions, parse_state_manager)
+
+    updated_table_definitions = sorted([tds.table_definition.table_name for tds in table_definition_states if tds.is_updated_or_dependencies_updated])
+
+    assert updated_table_definitions == [
+        'AccessControlledOffchainAggregator_event_AnswerUpdated',
+        'EACAggregatorProxy_call_confirmAggregator',
+        'view_AccessControlledOffchainAggregator_info'
+    ]
+


### PR DESCRIPTION
Problem: when table definitions are updated and PRs are merged, we need to perform some manual actions in order for the historical data for the updated table definitions to be updated.

Solution: persist the sha256 of table definition contents in a GCS bucket, compare it with latest content hashes to determine whether the historical data needs to be updated