### PR TITLE
Added TokenExchange events for Curve TricryptoOptimized pools

### DIFF
--- a/dags/resources/stages/parse/table_definitions/curve/TricryptoOptimized_event_TokenExchange.json
+++ b/dags/resources/stages/parse/table_definitions/curve/TricryptoOptimized_event_TokenExchange.json
@@ -1,0 +1,91 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "buyer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "sold_id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "tokens_sold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "bought_id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "tokens_bought",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "fee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "name": "packed_price_scale",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TokenExchange",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x4ebdf703948ddcea3b11f675b4d1fba9d2414a14', '0x7f86bf177dd4f3494b841a37e810a34dd56c829b', '0xf5f5b97624542d72a9e06f04804bf81baa15e2b4', '0x2889302a794da87fbf1d6db415c1492194663d13', '0x5426178799ee0a0181a89b4f57efddfab49941ec'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "curve",
+        "schema": [
+            {
+                "description": "",
+                "name": "buyer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sold_id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokens_sold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "bought_id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokens_bought",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "packed_price_scale",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "TricryptoOptimized_event_TokenExchange"
+    }
+}


### PR DESCRIPTION
## What?
Added support for Curve TokenExchange events for the 5 [Tricrypto Optimized](https://github.com/curvefi/tricrypto-ng/blob/main/contracts/main/CurveTricryptoOptimizedWETH.vy) pools, which use a non-standard event abi

address | name
-- | --
0x4ebdf703948ddcea3b11f675b4d1fba9d2414a14 | TriCRV
0x7f86bf177dd4f3494b841a37e810a34dd56c829b | TricryptoUSDC
0xf5f5b97624542d72a9e06f04804bf81baa15e2b4 | TricryptoUSDT
0x2889302a794da87fbf1d6db415c1492194663d13 | TricryptoLLAMA
0x5426178799ee0a0181a89b4f57efddfab49941ec | TricryptoINV





## How? 
I used the [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definition, and added the rest of the pool contracts to it