### PR TITLE
Add PythOracle contract

### DIFF
--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_AdminChanged.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_AdminChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "previousAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "AdminChanged",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousAdmin",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newAdmin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_AdminChanged"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_BatchPriceFeedUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_BatchPriceFeedUpdate.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "chainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "sequenceNumber",
+                    "type": "uint64"
+                }
+            ],
+            "name": "BatchPriceFeedUpdate",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "chainId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "sequenceNumber",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_BatchPriceFeedUpdate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_BeaconUpgraded.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_BeaconUpgraded.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "beacon",
+                    "type": "address"
+                }
+            ],
+            "name": "BeaconUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "beacon",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_BeaconUpgraded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_ContractUpgraded.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_ContractUpgraded.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldImplementation",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "ContractUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldImplementation",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newImplementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_ContractUpgraded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_DataSourcesSet.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_DataSourcesSet.json
@@ -1,0 +1,67 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource[]",
+                    "name": "oldDataSources",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource[]",
+                    "name": "newDataSources",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "DataSourcesSet",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldDataSources",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newDataSources",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_DataSourcesSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_FeeSet.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_FeeSet.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FeeSet",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_FeeSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_GovernanceDataSourceSet.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_GovernanceDataSourceSet.json
@@ -1,0 +1,102 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource",
+                    "name": "oldDataSource",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource",
+                    "name": "newDataSource",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "initialSequence",
+                    "type": "uint64"
+                }
+            ],
+            "name": "GovernanceDataSourceSet",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "chainId",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "emitterAddress",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "oldDataSource",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "chainId",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "emitterAddress",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "newDataSource",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "name": "initialSequence",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_GovernanceDataSourceSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_Initialized.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_Initialized.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "version",
+                    "type": "uint8"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_Initialized"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_PriceFeedUpdate.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_PriceFeedUpdate.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "publishTime",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int64",
+                    "name": "price",
+                    "type": "int64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "conf",
+                    "type": "uint64"
+                }
+            ],
+            "name": "PriceFeedUpdate",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "publishTime",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "price",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "conf",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_PriceFeedUpdate"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_Upgraded.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_Upgraded.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "Upgraded",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_Upgraded"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_ValidPeriodSet.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_ValidPeriodSet.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldValidPeriod",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newValidPeriod",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ValidPeriodSet",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldValidPeriod",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newValidPeriod",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_ValidPeriodSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_WormholeAddressSet.json
+++ b/dags/resources/stages/parse/table_definitions/pyth/PythOracle_event_WormholeAddressSet.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldWormholeAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newWormholeAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "WormholeAddressSet",
+            "type": "event"
+        },
+        "contract_address": "0x4305fb66699c3b2702d4d05cf36551390a4c69c6",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "pyth",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldWormholeAddress",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newWormholeAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PythOracle_event_WormholeAddressSet"
+    }
+}


### PR DESCRIPTION
## What?
Add support for Pyth events.

## How? 
 I used [abi-parser](https://nansen-contract-parser-prod.web.app/) build the table definitions. The address is listed here https://docs.pyth.network/documentation/pythnet-price-feeds/evm I replaced the implementation address with the proxy address

## Related PRs (optional)
PRs that are related to this or may need to be deployed before this PR

## Anything Else?
