### PR TITLE
Uniswap X execute calls

### DIFF
--- a/dags/resources/stages/parse/table_definitions/uniswap/ExclusiveDutchOrderReactor_call_execute.json
+++ b/dags/resources/stages/parse/table_definitions/uniswap/ExclusiveDutchOrderReactor_call_execute.json
@@ -1,0 +1,56 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes",
+                            "name": "order",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "sig",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct SignedOrder",
+                    "name": "order",
+                    "type": "tuple"
+                }
+            ],
+            "name": "execute",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0x6000da47483062a0d734ba3dc7576ce6a0b645c4",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "uniswap",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "order",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "sig",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "order",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ExclusiveDutchOrderReactor_call_execute"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/uniswap/ExclusiveDutchOrderReactor_call_executeBatch.json
+++ b/dags/resources/stages/parse/table_definitions/uniswap/ExclusiveDutchOrderReactor_call_executeBatch.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes",
+                            "name": "order",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "sig",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct SignedOrder[]",
+                    "name": "orders",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "executeBatch",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0x6000da47483062a0d734ba3dc7576ce6a0b645c4",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "uniswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "orders",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ExclusiveDutchOrderReactor_call_executeBatch"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/uniswap/ExclusiveDutchOrderReactor_call_executeBatchWithCallback.json
+++ b/dags/resources/stages/parse/table_definitions/uniswap/ExclusiveDutchOrderReactor_call_executeBatchWithCallback.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes",
+                            "name": "order",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "sig",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct SignedOrder[]",
+                    "name": "orders",
+                    "type": "tuple[]"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "callbackData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "executeBatchWithCallback",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0x6000da47483062a0d734ba3dc7576ce6a0b645c4",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "uniswap",
+        "schema": [
+            {
+                "description": "",
+                "name": "orders",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "callbackData",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ExclusiveDutchOrderReactor_call_executeBatchWithCallback"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/uniswap/ExclusiveDutchOrderReactor_call_executeWithCallback.json
+++ b/dags/resources/stages/parse/table_definitions/uniswap/ExclusiveDutchOrderReactor_call_executeWithCallback.json
@@ -1,0 +1,66 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes",
+                            "name": "order",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "sig",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct SignedOrder",
+                    "name": "order",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "callbackData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "executeWithCallback",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0x6000da47483062a0d734ba3dc7576ce6a0b645c4",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "uniswap",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "order",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "sig",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "order",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "name": "callbackData",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "ExclusiveDutchOrderReactor_call_executeWithCallback"
+    }
+}


### PR DESCRIPTION
## What?
Added support for Uniswap X execute calls: `execute`, `executeBatch`, `executeWithCallback`, `executeBatchWithCallback`

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions
