### PR TITLE
add definitions for Seaport 1.4 & 1.5 call functions

### DIFF
--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAdvancedOrder.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAdvancedOrder.json
@@ -1,0 +1,322 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "numerator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "denominator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "extraData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct AdvancedOrder",
+                    "name": "",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum Side",
+                            "name": "side",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "index",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32[]",
+                            "name": "criteriaProof",
+                            "type": "bytes32[]"
+                        }
+                    ],
+                    "internalType": "struct CriteriaResolver[]",
+                    "name": "",
+                    "type": "tuple[]"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "fulfillerConduitKey",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                }
+            ],
+            "name": "fulfillAdvancedOrder",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "fulfilled",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x00000000000001ad428e4906ae43d8f9852d0dd6', '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "offerer",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "zone",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "offer",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "consideration",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "orderType",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "startTime",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "endTime",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "zoneHash",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "salt",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "conduitKey",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "totalOriginalConsiderationItems",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "parameters",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "name": "numerator",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "denominator",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "signature",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "extraData",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fulfillerConduitKey",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SeaportV14_call_fulfillAdvancedOrder"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAdvancedOrder.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAdvancedOrder.json
@@ -147,7 +147,7 @@
                         }
                     ],
                     "internalType": "struct AdvancedOrder",
-                    "name": "",
+                    "name": "advancedOrder",
                     "type": "tuple"
                 },
                 {
@@ -179,7 +179,7 @@
                         }
                     ],
                     "internalType": "struct CriteriaResolver[]",
-                    "name": "",
+                    "name": "criteriaResolvers",
                     "type": "tuple[]"
                 },
                 {
@@ -297,12 +297,12 @@
                         "type": "STRING"
                     }
                 ],
-                "name": "unnamedField0",
+                "name": "advancedOrder",
                 "type": "RECORD"
             },
             {
                 "description": "",
-                "name": "unnamedField1",
+                "name": "criteriaResolvers",
                 "type": "STRING"
             },
             {

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAdvancedOrder.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAdvancedOrder.json
@@ -297,12 +297,12 @@
                         "type": "STRING"
                     }
                 ],
-                "name": "",
+                "name": "unnamedField0",
                 "type": "RECORD"
             },
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField1",
                 "type": "STRING"
             },
             {

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableAdvancedOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableAdvancedOrders.json
@@ -1,0 +1,341 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "numerator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "denominator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "extraData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct AdvancedOrder[]",
+                    "name": "",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum Side",
+                            "name": "side",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "index",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32[]",
+                            "name": "criteriaProof",
+                            "type": "bytes32[]"
+                        }
+                    ],
+                    "internalType": "struct CriteriaResolver[]",
+                    "name": "",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "itemIndex",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct FulfillmentComponent[][]",
+                    "name": "",
+                    "type": "tuple[][]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "itemIndex",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct FulfillmentComponent[][]",
+                    "name": "",
+                    "type": "tuple[][]"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "fulfillerConduitKey",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "maximumFulfilled",
+                    "type": "uint256"
+                }
+            ],
+            "name": "fulfillAvailableAdvancedOrders",
+            "outputs": [
+                {
+                    "internalType": "bool[]",
+                    "name": "",
+                    "type": "bool[]"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifier",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct ReceivedItem",
+                            "name": "item",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct Execution[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x00000000000001ad428e4906ae43d8f9852d0dd6', '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "schema": [
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fulfillerConduitKey",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "maximumFulfilled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SeaportV14_call_fulfillAvailableAdvancedOrders"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableAdvancedOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableAdvancedOrders.json
@@ -301,22 +301,22 @@
         "schema": [
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField0",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField1",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField2",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField3",
                 "type": "STRING"
             },
             {

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableAdvancedOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableAdvancedOrders.json
@@ -147,7 +147,7 @@
                         }
                     ],
                     "internalType": "struct AdvancedOrder[]",
-                    "name": "",
+                    "name": "advancedOrder",
                     "type": "tuple[]"
                 },
                 {
@@ -179,7 +179,7 @@
                         }
                     ],
                     "internalType": "struct CriteriaResolver[]",
-                    "name": "",
+                    "name": "criteriaResolvers",
                     "type": "tuple[]"
                 },
                 {
@@ -196,7 +196,7 @@
                         }
                     ],
                     "internalType": "struct FulfillmentComponent[][]",
-                    "name": "",
+                    "name": "offerFulfillments",
                     "type": "tuple[][]"
                 },
                 {
@@ -213,7 +213,7 @@
                         }
                     ],
                     "internalType": "struct FulfillmentComponent[][]",
-                    "name": "",
+                    "name": "considerationFulfillments",
                     "type": "tuple[][]"
                 },
                 {
@@ -236,7 +236,7 @@
             "outputs": [
                 {
                     "internalType": "bool[]",
-                    "name": "",
+                    "name": "availableOrders",
                     "type": "bool[]"
                 },
                 {
@@ -285,7 +285,7 @@
                         }
                     ],
                     "internalType": "struct Execution[]",
-                    "name": "",
+                    "name": "executions",
                     "type": "tuple[]"
                 }
             ],
@@ -301,22 +301,22 @@
         "schema": [
             {
                 "description": "",
-                "name": "unnamedField0",
+                "name": "advancedOrders",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "unnamedField1",
+                "name": "criteriaResolvers",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "unnamedField2",
+                "name": "offerFulfillments",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "unnamedField3",
+                "name": "considerationFulfillments",
                 "type": "STRING"
             },
             {

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableOrders.json
@@ -1,0 +1,279 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct Order[]",
+                    "name": "",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "itemIndex",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct FulfillmentComponent[][]",
+                    "name": "",
+                    "type": "tuple[][]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "itemIndex",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct FulfillmentComponent[][]",
+                    "name": "",
+                    "type": "tuple[][]"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "fulfillerConduitKey",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "maximumFulfilled",
+                    "type": "uint256"
+                }
+            ],
+            "name": "fulfillAvailableOrders",
+            "outputs": [
+                {
+                    "internalType": "bool[]",
+                    "name": "",
+                    "type": "bool[]"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifier",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct ReceivedItem",
+                            "name": "item",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct Execution[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x00000000000001ad428e4906ae43d8f9852d0dd6', '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "schema": [
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "fulfillerConduitKey",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "maximumFulfilled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SeaportV14_call_fulfillAvailableOrders"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableOrders.json
@@ -132,7 +132,7 @@
                         }
                     ],
                     "internalType": "struct Order[]",
-                    "name": "",
+                    "name": "orders",
                     "type": "tuple[]"
                 },
                 {
@@ -149,7 +149,7 @@
                         }
                     ],
                     "internalType": "struct FulfillmentComponent[][]",
-                    "name": "",
+                    "name": "offerFulfillments",
                     "type": "tuple[][]"
                 },
                 {
@@ -166,7 +166,7 @@
                         }
                     ],
                     "internalType": "struct FulfillmentComponent[][]",
-                    "name": "",
+                    "name": "considerationFulfillments",
                     "type": "tuple[][]"
                 },
                 {
@@ -184,7 +184,7 @@
             "outputs": [
                 {
                     "internalType": "bool[]",
-                    "name": "",
+                    "name": "availableOrders",
                     "type": "bool[]"
                 },
                 {
@@ -233,7 +233,7 @@
                         }
                     ],
                     "internalType": "struct Execution[]",
-                    "name": "",
+                    "name": "executions",
                     "type": "tuple[]"
                 }
             ],
@@ -249,17 +249,17 @@
         "schema": [
             {
                 "description": "",
-                "name": "unnamedField0",
+                "name": "orders",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "unnamedField1",
+                "name": "offerFulfillments",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "unnamedField2",
+                "name": "considerationFulfillments",
                 "type": "STRING"
             },
             {

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillAvailableOrders.json
@@ -249,17 +249,17 @@
         "schema": [
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField0",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField1",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField2",
                 "type": "STRING"
             },
             {

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillBasicOrder.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillBasicOrder.json
@@ -1,0 +1,234 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "considerationToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "considerationIdentifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "considerationAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address payable",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "zone",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "offerToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "offerIdentifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "offerAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum BasicOrderType",
+                            "name": "basicOrderType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "startTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "endTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "zoneHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "salt",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "offererConduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "fulfillerConduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalOriginalAdditionalRecipients",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct AdditionalRecipient[]",
+                            "name": "additionalRecipients",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct BasicOrderParameters",
+                    "name": "parameters",
+                    "type": "tuple"
+                }
+            ],
+            "name": "fulfillBasicOrder",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "fulfilled",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x00000000000001ad428e4906ae43d8f9852d0dd6', '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "considerationToken",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "considerationIdentifier",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "considerationAmount",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "offerer",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "zone",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "offerToken",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "offerIdentifier",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "offerAmount",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "basicOrderType",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "startTime",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "endTime",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "zoneHash",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "salt",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "offererConduitKey",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fulfillerConduitKey",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "totalOriginalAdditionalRecipients",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "additionalRecipients",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "signature",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "parameters",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SeaportV14_call_fulfillBasicOrder"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillBasicOrder_efficient_6GL6yc.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillBasicOrder_efficient_6GL6yc.json
@@ -1,0 +1,234 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "considerationToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "considerationIdentifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "considerationAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address payable",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "zone",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "offerToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "offerIdentifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "offerAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum BasicOrderType",
+                            "name": "basicOrderType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "startTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "endTime",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "zoneHash",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "salt",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "offererConduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "fulfillerConduitKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "totalOriginalAdditionalRecipients",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct AdditionalRecipient[]",
+                            "name": "additionalRecipients",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct BasicOrderParameters",
+                    "name": "parameters",
+                    "type": "tuple"
+                }
+            ],
+            "name": "fulfillBasicOrder_efficient_6GL6yc",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "fulfilled",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x00000000000001ad428e4906ae43d8f9852d0dd6', '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "considerationToken",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "considerationIdentifier",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "considerationAmount",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "offerer",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "zone",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "offerToken",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "offerIdentifier",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "offerAmount",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "basicOrderType",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "startTime",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "endTime",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "zoneHash",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "salt",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "offererConduitKey",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "fulfillerConduitKey",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "totalOriginalAdditionalRecipients",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "additionalRecipients",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "signature",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "parameters",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SeaportV14_call_fulfillBasicOrder_efficient_6GL6yc"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillOrder.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillOrder.json
@@ -230,7 +230,7 @@
                         "type": "STRING"
                     }
                 ],
-                "name": "",
+                "name": "unnamedField0",
                 "type": "RECORD"
             },
             {

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillOrder.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillOrder.json
@@ -132,7 +132,7 @@
                         }
                     ],
                     "internalType": "struct Order",
-                    "name": "",
+                    "name": "order",
                     "type": "tuple"
                 },
                 {

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillOrder.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillOrder.json
@@ -1,0 +1,245 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct Order",
+                    "name": "",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "fulfillerConduitKey",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "fulfillOrder",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "fulfilled",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x00000000000001ad428e4906ae43d8f9852d0dd6', '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "schema": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "fields": [
+                            {
+                                "description": "",
+                                "name": "offerer",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "zone",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "offer",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "consideration",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "orderType",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "startTime",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "endTime",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "zoneHash",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "salt",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "conduitKey",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "",
+                                "name": "totalOriginalConsiderationItems",
+                                "type": "STRING"
+                            }
+                        ],
+                        "name": "parameters",
+                        "type": "RECORD"
+                    },
+                    {
+                        "description": "",
+                        "name": "signature",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "name": "fulfillerConduitKey",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SeaportV14_call_fulfillOrder"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillOrder.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_fulfillOrder.json
@@ -230,7 +230,7 @@
                         "type": "STRING"
                     }
                 ],
-                "name": "unnamedField0",
+                "name": "order",
                 "type": "RECORD"
             },
             {

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchAdvancedOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchAdvancedOrders.json
@@ -147,7 +147,7 @@
                         }
                     ],
                     "internalType": "struct AdvancedOrder[]",
-                    "name": "",
+                    "name": "advancedOrders",
                     "type": "tuple[]"
                 },
                 {
@@ -179,7 +179,7 @@
                         }
                     ],
                     "internalType": "struct CriteriaResolver[]",
-                    "name": "",
+                    "name": "criteriaResolvers",
                     "type": "tuple[]"
                 },
                 {
@@ -220,7 +220,7 @@
                         }
                     ],
                     "internalType": "struct Fulfillment[]",
-                    "name": "",
+                    "name": "fulfillments",
                     "type": "tuple[]"
                 },
                 {
@@ -277,7 +277,7 @@
                         }
                     ],
                     "internalType": "struct Execution[]",
-                    "name": "",
+                    "name": "executions",
                     "type": "tuple[]"
                 }
             ],
@@ -293,17 +293,17 @@
         "schema": [
             {
                 "description": "",
-                "name": "unnamedField0",
+                "name": "advancedOrders",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "unnamedField1",
+                "name": "criteriaResolvers",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "unnamedField2",
+                "name": "fulfillments",
                 "type": "STRING"
             },
             {

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchAdvancedOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchAdvancedOrders.json
@@ -293,17 +293,17 @@
         "schema": [
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField0",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField1",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField2",
                 "type": "STRING"
             },
             {

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchAdvancedOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchAdvancedOrders.json
@@ -1,0 +1,318 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "numerator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "uint120",
+                            "name": "denominator",
+                            "type": "uint120"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "extraData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct AdvancedOrder[]",
+                    "name": "",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "orderIndex",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "enum Side",
+                            "name": "side",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "index",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes32[]",
+                            "name": "criteriaProof",
+                            "type": "bytes32[]"
+                        }
+                    ],
+                    "internalType": "struct CriteriaResolver[]",
+                    "name": "",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "orderIndex",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "itemIndex",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct FulfillmentComponent[]",
+                            "name": "offerComponents",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "orderIndex",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "itemIndex",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct FulfillmentComponent[]",
+                            "name": "considerationComponents",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "internalType": "struct Fulfillment[]",
+                    "name": "",
+                    "type": "tuple[]"
+                },
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                }
+            ],
+            "name": "matchAdvancedOrders",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifier",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct ReceivedItem",
+                            "name": "item",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct Execution[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x00000000000001ad428e4906ae43d8f9852d0dd6', '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "schema": [
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SeaportV14_call_matchAdvancedOrders"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchOrders.json
@@ -241,12 +241,12 @@
         "schema": [
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField0",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "",
+                "name": "unnamedField1",
                 "type": "STRING"
             }
         ],

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchOrders.json
@@ -1,0 +1,256 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "offerer",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "zone",
+                                    "type": "address"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        }
+                                    ],
+                                    "internalType": "struct OfferItem[]",
+                                    "name": "offer",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "internalType": "enum ItemType",
+                                            "name": "itemType",
+                                            "type": "uint8"
+                                        },
+                                        {
+                                            "internalType": "address",
+                                            "name": "token",
+                                            "type": "address"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "identifierOrCriteria",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "startAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "uint256",
+                                            "name": "endAmount",
+                                            "type": "uint256"
+                                        },
+                                        {
+                                            "internalType": "address payable",
+                                            "name": "recipient",
+                                            "type": "address"
+                                        }
+                                    ],
+                                    "internalType": "struct ConsiderationItem[]",
+                                    "name": "consideration",
+                                    "type": "tuple[]"
+                                },
+                                {
+                                    "internalType": "enum OrderType",
+                                    "name": "orderType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "startTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "endTime",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "zoneHash",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "salt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "conduitKey",
+                                    "type": "bytes32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "totalOriginalConsiderationItems",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct OrderParameters",
+                            "name": "parameters",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "signature",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct Order[]",
+                    "name": "",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "orderIndex",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "itemIndex",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct FulfillmentComponent[]",
+                            "name": "offerComponents",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "orderIndex",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "itemIndex",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct FulfillmentComponent[]",
+                            "name": "considerationComponents",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "internalType": "struct Fulfillment[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "matchOrders",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "enum ItemType",
+                                    "name": "itemType",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "token",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "identifier",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "address payable",
+                                    "name": "recipient",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct ReceivedItem",
+                            "name": "item",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "offerer",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "conduitKey",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct Execution[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x00000000000001ad428e4906ae43d8f9852d0dd6', '0x00000000000000adc04c56bf30ac9d3c0aaf14dc'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "seaport",
+        "schema": [
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "SeaportV14_call_matchOrders"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchOrders.json
+++ b/dags/resources/stages/parse/table_definitions/seaport/SeaportV14_call_matchOrders.json
@@ -132,7 +132,7 @@
                         }
                     ],
                     "internalType": "struct Order[]",
-                    "name": "",
+                    "name": "orders",
                     "type": "tuple[]"
                 },
                 {
@@ -173,7 +173,7 @@
                         }
                     ],
                     "internalType": "struct Fulfillment[]",
-                    "name": "",
+                    "name": "fulfillments",
                     "type": "tuple[]"
                 }
             ],
@@ -225,7 +225,7 @@
                         }
                     ],
                     "internalType": "struct Execution[]",
-                    "name": "",
+                    "name": "executions",
                     "type": "tuple[]"
                 }
             ],
@@ -241,12 +241,12 @@
         "schema": [
             {
                 "description": "",
-                "name": "unnamedField0",
+                "name": "orders",
                 "type": "STRING"
             },
             {
                 "description": "",
-                "name": "unnamedField1",
+                "name": "fulfillments",
                 "type": "STRING"
             }
         ],


### PR DESCRIPTION
## What?
add definitions for Seaport 1.4 & 1.5 call functions

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions

## Related PRs (optional)
n/a

## Anything Else?
