### PR TITLE
EigenLayer events and calls

### DIFF
--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_claimDelayedWithdrawals.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_claimDelayedWithdrawals.json
@@ -37,6 +37,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_claimDelayedWithdrawals"
+        "table_name": "DelayedWithdrawalRouter_call_claimDelayedWithdrawals"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_claimDelayedWithdrawals.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_claimDelayedWithdrawals.json
@@ -23,7 +23,7 @@
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "eigenlayer",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_claimDelayedWithdrawals.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_claimDelayedWithdrawals.json
@@ -1,0 +1,42 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "maxNumberOfDelayedWithdrawalsToClaim",
+                    "type": "uint256"
+                }
+            ],
+            "name": "claimDelayedWithdrawals",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "maxNumberOfDelayedWithdrawalsToClaim",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_claimDelayedWithdrawals"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_claimDelayedWithdrawals.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_claimDelayedWithdrawals.json
@@ -18,7 +18,7 @@
             "stateMutability": "nonpayable",
             "type": "function"
         },
-        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "contract_address": "0x7fe7e9cc0f274d2435ad5d56d5fa73e47f6a23d8",
         "field_mapping": {},
         "type": "trace"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_createDelayedWithdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_createDelayedWithdrawal.json
@@ -18,7 +18,7 @@
             "stateMutability": "payable",
             "type": "function"
         },
-        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "contract_address": "0x7fe7e9cc0f274d2435ad5d56d5fa73e47f6a23d8",
         "field_mapping": {},
         "type": "trace"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_createDelayedWithdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_createDelayedWithdrawal.json
@@ -37,6 +37,6 @@
             }
         ],
         "table_description": "",
-        "table_name": "<TABLE_PREFIX>_event_createDelayedWithdrawal"
+        "table_name": "DelayedWithdrawalRouter_call_createDelayedWithdrawal"
     }
 }

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_createDelayedWithdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_createDelayedWithdrawal.json
@@ -1,0 +1,42 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "podOwner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                }
+            ],
+            "name": "createDelayedWithdrawal",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "<INSERT_DATASET_NAME>",
+        "schema": [
+            {
+                "description": "",
+                "name": "podOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "<TABLE_PREFIX>_event_createDelayedWithdrawal"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_createDelayedWithdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_call_createDelayedWithdrawal.json
@@ -23,7 +23,7 @@
         "type": "trace"
     },
     "table": {
-        "dataset_name": "<INSERT_DATASET_NAME>",
+        "dataset_name": "eigenlayer",
         "schema": [
             {
                 "description": "",

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_DelayedWithdrawalCreated.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_DelayedWithdrawalCreated.json
@@ -31,7 +31,7 @@
             "name": "DelayedWithdrawalCreated",
             "type": "event"
         },
-        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "contract_address": "0x7fe7e9cc0f274d2435ad5d56d5fa73e47f6a23d8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_DelayedWithdrawalCreated.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_DelayedWithdrawalCreated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "podOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DelayedWithdrawalCreated",
+            "type": "event"
+        },
+        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "podOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "DelayedWithdrawalRouter_event_DelayedWithdrawalCreated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_DelayedWithdrawalsClaimed.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_DelayedWithdrawalsClaimed.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amountClaimed",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "delayedWithdrawalsCompleted",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DelayedWithdrawalsClaimed",
+            "type": "event"
+        },
+        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountClaimed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "delayedWithdrawalsCompleted",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "DelayedWithdrawalRouter_event_DelayedWithdrawalsClaimed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_DelayedWithdrawalsClaimed.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_DelayedWithdrawalsClaimed.json
@@ -25,7 +25,7 @@
             "name": "DelayedWithdrawalsClaimed",
             "type": "event"
         },
-        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "contract_address": "0x7fe7e9cc0f274d2435ad5d56d5fa73e47f6a23d8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Initialized.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Initialized.json
@@ -13,7 +13,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "contract_address": "0x7fe7e9cc0f274d2435ad5d56d5fa73e47f6a23d8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Initialized.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Initialized.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "version",
+                    "type": "uint8"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "DelayedWithdrawalRouter_event_Initialized"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "DelayedWithdrawalRouter_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_OwnershipTransferred.json
@@ -19,7 +19,7 @@
             "name": "OwnershipTransferred",
             "type": "event"
         },
-        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "contract_address": "0x7fe7e9cc0f274d2435ad5d56d5fa73e47f6a23d8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Paused.json
@@ -19,7 +19,7 @@
             "name": "Paused",
             "type": "event"
         },
-        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "contract_address": "0x7fe7e9cc0f274d2435ad5d56d5fa73e47f6a23d8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Paused.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newPausedStatus",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPausedStatus",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "DelayedWithdrawalRouter_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_PauserRegistrySet.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_PauserRegistrySet.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "contract IPauserRegistry",
+                    "name": "pauserRegistry",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IPauserRegistry",
+                    "name": "newPauserRegistry",
+                    "type": "address"
+                }
+            ],
+            "name": "PauserRegistrySet",
+            "type": "event"
+        },
+        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "pauserRegistry",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPauserRegistry",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "DelayedWithdrawalRouter_event_PauserRegistrySet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_PauserRegistrySet.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_PauserRegistrySet.json
@@ -19,7 +19,7 @@
             "name": "PauserRegistrySet",
             "type": "event"
         },
-        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "contract_address": "0x7fe7e9cc0f274d2435ad5d56d5fa73e47f6a23d8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Unpaused.json
@@ -19,7 +19,7 @@
             "name": "Unpaused",
             "type": "event"
         },
-        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "contract_address": "0x7fe7e9cc0f274d2435ad5d56d5fa73e47f6a23d8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_Unpaused.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newPausedStatus",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPausedStatus",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "DelayedWithdrawalRouter_event_Unpaused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_WithdrawalDelayBlocksSet.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_WithdrawalDelayBlocksSet.json
@@ -19,7 +19,7 @@
             "name": "WithdrawalDelayBlocksSet",
             "type": "event"
         },
-        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "contract_address": "0x7fe7e9cc0f274d2435ad5d56d5fa73e47f6a23d8",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_WithdrawalDelayBlocksSet.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/DelayedWithdrawalRouter_event_WithdrawalDelayBlocksSet.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "previousValue",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawalDelayBlocksSet",
+            "type": "event"
+        },
+        "contract_address": "0x44bcb0e01cd0c5060d4bb1a07b42580ef983e2af",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousValue",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newValue",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "DelayedWithdrawalRouter_event_WithdrawalDelayBlocksSet"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_stake.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_stake.json
@@ -1,0 +1,52 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "pubkey",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "depositDataRoot",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "stake",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "pubkey",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "signature",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "depositDataRoot",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenPod_call_stake"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_verifyAndProcessWithdrawal.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_verifyAndProcessWithdrawal.json
@@ -1,0 +1,144 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes",
+                            "name": "blockHeaderProof",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "withdrawalProof",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "slotProof",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "executionPayloadProof",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "blockNumberProof",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "blockHeaderRootIndex",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "withdrawalIndex",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "blockHeaderRoot",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "blockBodyRoot",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "slotRoot",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "blockNumberRoot",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "executionPayloadRoot",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct BeaconChainProofs.WithdrawalProofs",
+                    "name": "withdrawalProofs",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "validatorFieldsProof",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "bytes32[]",
+                    "name": "validatorFields",
+                    "type": "bytes32[]"
+                },
+                {
+                    "internalType": "bytes32[]",
+                    "name": "withdrawalFields",
+                    "type": "bytes32[]"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "beaconChainETHStrategyIndex",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint64",
+                    "name": "oracleBlockNumber",
+                    "type": "uint64"
+                }
+            ],
+            "name": "verifyAndProcessWithdrawal",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "withdrawalProofs",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "validatorFieldsProof",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "validatorFields",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "withdrawalFields",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "beaconChainETHStrategyIndex",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracleBlockNumber",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenPod_call_verifyAndProcessWithdrawal"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_verifyOvercommittedStake.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_verifyOvercommittedStake.json
@@ -1,0 +1,89 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint40",
+                    "name": "validatorIndex",
+                    "type": "uint40"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes",
+                            "name": "validatorFieldsProof",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "validatorBalanceProof",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "balanceRoot",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct BeaconChainProofs.ValidatorFieldsAndBalanceProofs",
+                    "name": "proofs",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes32[]",
+                    "name": "validatorFields",
+                    "type": "bytes32[]"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "beaconChainETHStrategyIndex",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint64",
+                    "name": "oracleBlockNumber",
+                    "type": "uint64"
+                }
+            ],
+            "name": "verifyOvercommittedStake",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "validatorIndex",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proofs",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "validatorFields",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "beaconChainETHStrategyIndex",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracleBlockNumber",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenPod_call_verifyOvercommittedStake"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_verifyWithdrawalCredentialsAndBalance.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_verifyWithdrawalCredentialsAndBalance.json
@@ -1,0 +1,79 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "uint64",
+                    "name": "oracleBlockNumber",
+                    "type": "uint64"
+                },
+                {
+                    "internalType": "uint40",
+                    "name": "validatorIndex",
+                    "type": "uint40"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes",
+                            "name": "validatorFieldsProof",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "validatorBalanceProof",
+                            "type": "bytes"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "balanceRoot",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct BeaconChainProofs.ValidatorFieldsAndBalanceProofs",
+                    "name": "proofs",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes32[]",
+                    "name": "validatorFields",
+                    "type": "bytes32[]"
+                }
+            ],
+            "name": "verifyWithdrawalCredentialsAndBalance",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "oracleBlockNumber",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "validatorIndex",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proofs",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "validatorFields",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenPod_call_verifyWithdrawalCredentialsAndBalance"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_withdrawBeforeRestaking.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_withdrawBeforeRestaking.json
@@ -1,0 +1,20 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [],
+            "name": "withdrawBeforeRestaking",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [],
+        "table_description": "",
+        "table_name": "EigenPod_call_withdrawBeforeRestaking"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_withdrawRestakedBeaconChainETH.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_call_withdrawRestakedBeaconChainETH.json
@@ -1,0 +1,42 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amountWei",
+                    "type": "uint256"
+                }
+            ],
+            "name": "withdrawRestakedBeaconChainETH",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountWei",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenPod_call_withdrawRestakedBeaconChainETH"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_EigenPodStaked.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_EigenPodStaked.json
@@ -13,7 +13,7 @@
             "name": "EigenPodStaked",
             "type": "event"
         },
-        "contract_address": "0x5a2a4f2f3c18f09179b6703e63d9edd165909073",
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_FullWithdrawalRedeemed.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_FullWithdrawalRedeemed.json
@@ -25,7 +25,7 @@
             "name": "FullWithdrawalRedeemed",
             "type": "event"
         },
-        "contract_address": "0x5a2a4f2f3c18f09179b6703e63d9edd165909073",
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_Initialized.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_Initialized.json
@@ -13,7 +13,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "0x5a2a4f2f3c18f09179b6703e63d9edd165909073",
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_PartialWithdrawalRedeemed.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_PartialWithdrawalRedeemed.json
@@ -25,7 +25,7 @@
             "name": "PartialWithdrawalRedeemed",
             "type": "event"
         },
-        "contract_address": "0x5a2a4f2f3c18f09179b6703e63d9edd165909073",
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_RestakedBeaconChainETHWithdrawn.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_RestakedBeaconChainETHWithdrawn.json
@@ -19,7 +19,7 @@
             "name": "RestakedBeaconChainETHWithdrawn",
             "type": "event"
         },
-        "contract_address": "0x5a2a4f2f3c18f09179b6703e63d9edd165909073",
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_ValidatorOvercommitted.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_ValidatorOvercommitted.json
@@ -13,7 +13,7 @@
             "name": "ValidatorOvercommitted",
             "type": "event"
         },
-        "contract_address": "0x5a2a4f2f3c18f09179b6703e63d9edd165909073",
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_ValidatorRestaked.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/EigenPod_event_ValidatorRestaked.json
@@ -13,7 +13,7 @@
             "name": "ValidatorRestaked",
             "type": "event"
         },
-        "contract_address": "0x5a2a4f2f3c18f09179b6703e63d9edd165909073",
+        "contract_address": "SELECT eigenPod FROM ref('EigenPodManager_event_PodDeployed')",
         "field_mapping": {},
         "type": "log"
     },

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/StrategyBaseTVLLimits_call_deposit.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/StrategyBaseTVLLimits_call_deposit.json
@@ -1,0 +1,48 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "contract IERC20",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "deposit",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "newShares",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT DISTINCT strategy FROM ref('StrategyManager_event_StrategyAddedToDepositWhitelist')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StrategyBaseTVLLimits_call_deposit"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenlayer/StrategyBaseTVLLimits_call_withdraw.json
+++ b/dags/resources/stages/parse/table_definitions/eigenlayer/StrategyBaseTVLLimits_call_withdraw.json
@@ -1,0 +1,52 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "depositor",
+                    "type": "address"
+                },
+                {
+                    "internalType": "contract IERC20",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amountShares",
+                    "type": "uint256"
+                }
+            ],
+            "name": "withdraw",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT DISTINCT strategy FROM ref('StrategyManager_event_StrategyAddedToDepositWhitelist')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "eigenlayer",
+        "schema": [
+            {
+                "description": "",
+                "name": "depositor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountShares",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StrategyBaseTVLLimits_call_withdraw"
+    }
+}


### PR DESCRIPTION
## What?
- Add EigenLayer Withdrawal Router events and calls
- Fix existing Pod events contract address source and add calls
- Add EigenLayer strategy calls 

## How? 
I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions

## Related PRs (optional)
None

## Anything Else?
**Some of the tables will need to be refreshed (EigenPod events tables) due to changing the "contract_address" field.**