### PR TITLE
Fix pendulum version in tests

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 jsonschema==3.2.0       # matches `composer-2.1.14-airflow-2.5.1`
+pendulum~=2.0.0         # pendulum.tz.timezone is removed in pendulum 3.0.0 which causes TypeError: 'module' object is not callable
 pytest


### PR DESCRIPTION
## What?
Fix pendulum version in tests

## Why?

Prevents an error in tests https://github.com/blockchain-etl/ethereum-etl-airflow/actions/runs/8027295703/job/21932297315

```
==================================== ERRORS ====================================
________________ ERROR collecting tests/test_dag_validation.py _________________
tests/test_dag_validation.py:4: in <module>
    from airflow.models import DagBag, Variable
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/airflow/__init__.py:42: in <module>
    from airflow import settings
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/airflow/settings.py:49: in <module>
    TIMEZONE = pendulum.tz.timezone("UTC")
E   TypeError: 'module' object is not callable
=========================== short test summary info ============================
ERROR tests/test_dag_validation.py - TypeError: 'module' object is not callable
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.33s ===============================
```