### PR TITLE
Eigenpie Staking events for Old Proxy

### DIFF
--- a/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_AssetDeposit.json
+++ b/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_AssetDeposit.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "depositor",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "depositAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "referral",
+                    "type": "address"
+                }
+            ],
+            "name": "AssetDeposit",
+            "type": "event"
+        },
+        "contract_address": "0x24db6717db1c75b9db6ea47164d8730b63875db7",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenpie",
+        "schema": [
+            {
+                "description": "",
+                "name": "depositor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "depositAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "referral",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenpieStakingOld_event_AssetDeposit"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_Initialized.json
+++ b/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_Initialized.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "version",
+                    "type": "uint8"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "0x24db6717db1c75b9db6ea47164d8730b63875db7",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenpie",
+        "schema": [
+            {
+                "description": "",
+                "name": "version",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenpieStakingOld_event_Initialized"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_MaxNodeDelegatorLimitUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_MaxNodeDelegatorLimitUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "maxNodeDelegatorLimit",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MaxNodeDelegatorLimitUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x24db6717db1c75b9db6ea47164d8730b63875db7",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenpie",
+        "schema": [
+            {
+                "description": "",
+                "name": "maxNodeDelegatorLimit",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenpieStakingOld_event_MaxNodeDelegatorLimitUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_MinAmountToDepositUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_MinAmountToDepositUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "minAmountToDeposit",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MinAmountToDepositUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x24db6717db1c75b9db6ea47164d8730b63875db7",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenpie",
+        "schema": [
+            {
+                "description": "",
+                "name": "minAmountToDeposit",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenpieStakingOld_event_MinAmountToDepositUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_NodeDelegatorAddedinQueue.json
+++ b/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_NodeDelegatorAddedinQueue.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address[]",
+                    "name": "nodeDelegatorContracts",
+                    "type": "address[]"
+                }
+            ],
+            "name": "NodeDelegatorAddedinQueue",
+            "type": "event"
+        },
+        "contract_address": "0x24db6717db1c75b9db6ea47164d8730b63875db7",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenpie",
+        "schema": [
+            {
+                "description": "",
+                "name": "nodeDelegatorContracts",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenpieStakingOld_event_NodeDelegatorAddedinQueue"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_Paused.json
+++ b/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_Paused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        "contract_address": "0x24db6717db1c75b9db6ea47164d8730b63875db7",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenpie",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenpieStakingOld_event_Paused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_Unpaused.json
+++ b/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_Unpaused.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        "contract_address": "0x24db6717db1c75b9db6ea47164d8730b63875db7",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenpie",
+        "schema": [
+            {
+                "description": "",
+                "name": "account",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenpieStakingOld_event_Unpaused"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_UpdatedEigenpieConfig.json
+++ b/dags/resources/stages/parse/table_definitions/eigenpie/EigenpieStakingOld_event_UpdatedEigenpieConfig.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "eigenpieConfig",
+                    "type": "address"
+                }
+            ],
+            "name": "UpdatedEigenpieConfig",
+            "type": "event"
+        },
+        "contract_address": "0x24db6717db1c75b9db6ea47164d8730b63875db7",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "eigenpie",
+        "schema": [
+            {
+                "description": "",
+                "name": "eigenpieConfig",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EigenpieStakingOld_event_UpdatedEigenpieConfig"
+    }
+}


### PR DESCRIPTION
Topic: Adding Eigenpie staking events for the old proxy contract. The current Staking contract events tables, for ex. `AssetDeposit`, do not pick up logs for the old Proxy contract due to having different topics/ABI. 

## What?
Add support for Eigenpie Staking events for the old proxy contract

## How? 
I used the [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions

## Related PRs (optional)
#675 

