### PR TITLE
increase max_num_updated_table_definitions

### DIFF
--- a/dags/ethereumetl_airflow/parse/parse_dataset_folder_logic.py
+++ b/dags/ethereumetl_airflow/parse/parse_dataset_folder_logic.py
@@ -67,7 +67,7 @@ def parse_dataset_folder(
     ]
 
     # Prevents accidentally running full refresh for many tables caused by bugs
-    max_num_updated_table_definitions = 50
+    max_num_updated_table_definitions = 60
     if len(updated_table_definitions) > max_num_updated_table_definitions:
         raise ValueError(
             f"More than {max_num_updated_table_definitions} will be fully refreshed. Please make sure not more than {max_num_updated_table_definitions} are updated"


### PR DESCRIPTION
After merging https://github.com/blockchain-etl/ethereum-etl-airflow/pull/739, CI/CD [failed on merge](https://github.com/blockchain-etl/ethereum-etl-airflow/actions/runs/9703086086/job/26780423989) due to too many updated table definitions -- though in this case I think it's not accidental, just a lot of definitions in a folder, 59 in total.

I think increasing the limit from 50 to 60 will cover this.