### PR TITLE
Hotfix for failing load_traces task due to value not fitting in the NUMERIC data type

### DIFF
--- a/dags/resources/stages/enrich/sqls/traces.sql
+++ b/dags/resources/stages/enrich/sqls/traces.sql
@@ -3,7 +3,7 @@ SELECT
     traces.transaction_index,
     traces.from_address,
     traces.to_address,
-    traces.value,
+    SAFE_CAST(traces.value AS NUMERIC) AS value,
     traces.input,
     traces.output,
     traces.trace_type,

--- a/dags/resources/stages/raw/schemas/traces.json
+++ b/dags/resources/stages/raw/schemas/traces.json
@@ -27,7 +27,7 @@
     },
     {
         "name": "value",
-        "type": "NUMERIC",
+        "type": "STRING",
         "description": "Value transferred in Wei"
     },
     {


### PR DESCRIPTION
## What?
Hotfix for failing load_traces task due to value not fitting in the NUMERIC data type

## How? 
Change the datatype STRING when loading, use SAFE_CAST() when merging

Example tx with large value: https://etherscan.io/tx/0x00ed8efcf66cc13022770c253de4f15edbf53a07471e3ce49913fae12098d6aa

More transactions with large value:
```
select *
from bigquery-public-data.crypto_ethereum.traces
where date(block_timestamp) = '2024-07-03'
and value is null
```
