### PR TITLE
Refresh kelpdao table

### DIFF
--- a/dags/resources/stages/parse/table_definitions/kelpdao/LRTWithdrawalManager_event_AssetWithdrawalQueued.json
+++ b/dags/resources/stages/parse/table_definitions/kelpdao/LRTWithdrawalManager_event_AssetWithdrawalQueued.json
@@ -50,5 +50,6 @@
         ],
         "table_description": "",
         "table_name": "LRTWithdrawalManager_event_AssetWithdrawalQueued"
-    }
+    },
+    "version": "1"
 }


### PR DESCRIPTION
Trigger full refresh of table LRTWithdrawalManager_event_AssetWithdrawalQueued to fix the error:

```
google.api_core.exceptions.BadRequest: 400 PATCH https://bigquery.googleapis.com/bigquery/v2/projects/blockchain-etl/datasets/ethereum_kelpdao/tables/LRTWithdrawalManager_event_AssetWithdrawalQueued?prettyPrint=false: Queries in UNION ALL have mismatched column count; query 1 has 9 columns, query 2 has 8 columns at [5:1]
```
