### PR TITLE
Update python 3.8 version in CI/CD

### DIFF
--- a/.github/workflows/cicd-on-pr.yml
+++ b/.github/workflows/cicd-on-pr.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8.12"
+          python-version: "3.8.18"
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install dependencies
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8.12"
+          python-version: "3.8.18"
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install dependencies


### PR DESCRIPTION
## What?
Updating the python version in the CI/CD because it was failing. An example of a failing check is [here](https://github.com/blockchain-etl/ethereum-etl-airflow/actions/runs/11333174317/job/31516802669).

## How? 
Updated python version to latest in 3.8

## Related PRs (optional)
PRs that are related to this or may need to be deployed before this PR

## Anything Else?
