### PR TITLE
Add StakeDAO CRV VoteMarket events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_BountyClosed.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_BountyClosed.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "remainingReward",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BountyClosed",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "remainingReward",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_BountyClosed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_BountyCreated.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_BountyCreated.json
@@ -1,0 +1,120 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "gauge",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "manager",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "rewardToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "numberOfPeriods",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "maxRewardPerVote",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "rewardPerPeriod",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "totalRewardAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "isUpgradeable",
+                    "type": "bool"
+                }
+            ],
+            "name": "BountyCreated",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "gauge",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "manager",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "rewardToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "numberOfPeriods",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "maxRewardPerVote",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "rewardPerPeriod",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "totalRewardAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "isUpgradeable",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_BountyCreated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_BountyDurationIncrease.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_BountyDurationIncrease.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "numberOfPeriods",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "totalRewardAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "maxRewardPerVote",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BountyDurationIncrease",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "numberOfPeriods",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "totalRewardAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "maxRewardPerVote",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_BountyDurationIncrease"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_BountyDurationIncreaseQueued.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_BountyDurationIncreaseQueued.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "numberOfPeriods",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "totalRewardAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "maxRewardPerVote",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BountyDurationIncreaseQueued",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "numberOfPeriods",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "totalRewardAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "maxRewardPerVote",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_BountyDurationIncreaseQueued"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_Claimed.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_Claimed.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "rewardToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "bountyId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "protocolFees",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "period",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Claimed",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "rewardToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "bountyId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "protocolFees",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "period",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_Claimed"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_FeeCollectorUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_FeeCollectorUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "feeCollector",
+                    "type": "address"
+                }
+            ],
+            "name": "FeeCollectorUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "feeCollector",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_FeeCollectorUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_FeeUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_FeeUpdated.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "fee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "fee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_FeeUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_FeesCollected.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_FeesCollected.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "rewardToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FeesCollected",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "rewardToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_FeesCollected"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_ManagerUpdated.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_ManagerUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "manager",
+                    "type": "address"
+                }
+            ],
+            "name": "ManagerUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "manager",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_ManagerUpdated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_OwnershipTransferred.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_OwnershipTransferred"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_PeriodRolledOver.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_PeriodRolledOver.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "id",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "periodId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "rewardPerPeriod",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PeriodRolledOver",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "periodId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "timestamp",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "rewardPerPeriod",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_PeriodRolledOver"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_RecipientSet.json
+++ b/dags/resources/stages/parse/table_definitions/stakedao/Platform_event_RecipientSet.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                }
+            ],
+            "name": "RecipientSet",
+            "type": "event"
+        },
+        "contract_address": "0x000000073d065fc33a3050c2d0e19c393a5699ba",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "stakedao",
+        "schema": [
+            {
+                "description": "",
+                "name": "sender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Platform_event_RecipientSet"
+    }
+}


### PR DESCRIPTION
Add support for StakeDAO CRV VoteMarket events (https://etherscan.io/address/0x000000073D065Fc33a3050C2d0E19C393a5699ba#events).



## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions.
