### PR TITLE
[Gauntlet] Euler V2 Generic Factory events

### DIFF
--- a/dags/resources/stages/parse/table_definitions/euler_v2/GenericFactory_event_Genesis.json
+++ b/dags/resources/stages/parse/table_definitions/euler_v2/GenericFactory_event_Genesis.json
@@ -1,0 +1,19 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Genesis",
+            "type": "event"
+        },
+        "contract_address": "0x29a56a1b8214d9cf7c5561811750d5cbdb45cc8e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "euler_v2",
+        "schema": [],
+        "table_description": "",
+        "table_name": "GenericFactory_event_Genesis"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/euler_v2/GenericFactory_event_ProxyCreated.json
+++ b/dags/resources/stages/parse/table_definitions/euler_v2/GenericFactory_event_ProxyCreated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "upgradeable",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "trailingData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "ProxyCreated",
+            "type": "event"
+        },
+        "contract_address": "0x29a56a1b8214d9cf7c5561811750d5cbdb45cc8e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "euler_v2",
+        "schema": [
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "upgradeable",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "trailingData",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GenericFactory_event_ProxyCreated"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/euler_v2/GenericFactory_event_SetImplementation.json
+++ b/dags/resources/stages/parse/table_definitions/euler_v2/GenericFactory_event_SetImplementation.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "SetImplementation",
+            "type": "event"
+        },
+        "contract_address": "0x29a56a1b8214d9cf7c5561811750d5cbdb45cc8e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "euler_v2",
+        "schema": [
+            {
+                "description": "",
+                "name": "newImplementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GenericFactory_event_SetImplementation"
+    }
+}

--- a/dags/resources/stages/parse/table_definitions/euler_v2/GenericFactory_event_SetUpgradeAdmin.json
+++ b/dags/resources/stages/parse/table_definitions/euler_v2/GenericFactory_event_SetUpgradeAdmin.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newUpgradeAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "SetUpgradeAdmin",
+            "type": "event"
+        },
+        "contract_address": "0x29a56a1b8214d9cf7c5561811750d5cbdb45cc8e",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "euler_v2",
+        "schema": [
+            {
+                "description": "",
+                "name": "newUpgradeAdmin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "GenericFactory_event_SetUpgradeAdmin"
+    }
+}


### PR DESCRIPTION
## What?
ie: Add support for Euler V2 Generic Factory events

## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions


This will enable support for vault events, as we will pull vault addresses from the ProxyCreated event output