### PR TITLE
Increase max number of updated table definitions to 70

### DIFF
--- a/.github/workflows/cicd-on-pr.yml
+++ b/.github/workflows/cicd-on-pr.yml
@@ -63,9 +63,9 @@ jobs:
           NUM_FILES=$(git diff --name-only master HEAD | grep '^dags/resources/stages/parse/table_definitions' | wc -l)
           echo "Number of changed files: $NUM_FILES"
           
-          # Fail the job if more than 50 files are changed
-          if [ "$NUM_FILES" -gt 50 ]; then
-            echo "Error: More than 50 files have been changed. Failing the job."
+          # Fail the job if more than 70 files are changed
+          if [ "$NUM_FILES" -gt 70 ]; then
+            echo "Error: More than 70 files have been changed. Failing the job."
             exit 1
           else
             echo "Number of changed files is within limit."

--- a/dags/ethereumetl_airflow/parse/parse_dataset_folder_logic.py
+++ b/dags/ethereumetl_airflow/parse/parse_dataset_folder_logic.py
@@ -67,10 +67,11 @@ def parse_dataset_folder(
     ]
 
     # Prevents accidentally running full refresh for many tables caused by bugs
-    max_num_updated_table_definitions = 50
-    if len(updated_table_definitions) > max_num_updated_table_definitions:
+    max_num_updated_table_definitions = 70
+    num_updated_table_definitions = len(updated_table_definitions)
+    if num_updated_table_definitions > max_num_updated_table_definitions:
         raise ValueError(
-            f"More than {max_num_updated_table_definitions} will be fully refreshed. Please make sure not more than {max_num_updated_table_definitions} are updated"
+            f"{num_updated_table_definitions} will be fully refreshed. Please make sure not more than {max_num_updated_table_definitions} are updated"
         )
 
     for index, table_definition_state in enumerate(table_definition_states):


### PR DESCRIPTION
## What?
Increase max number of updated table definitions to 70

# Why?

Fix build failure https://github.com/blockchain-etl/ethereum-etl-airflow/actions/runs/13707714519/job/38336987329
