### PR TITLE
Comment out the verification task for traces transactions count

### DIFF
--- a/dags/ethereumetl_airflow/build_load_dag.py
+++ b/dags/ethereumetl_airflow/build_load_dag.py
@@ -311,8 +311,8 @@ def build_load_dag(
     verify_token_transfers_have_latest_task = add_verify_tasks('token_transfers_have_latest',
                                                                [enrich_token_transfers_task])
     verify_traces_blocks_count_task = add_verify_tasks('traces_blocks_count', [enrich_blocks_task, enrich_traces_task])
-    verify_traces_transactions_count_task = add_verify_tasks(
-        'traces_transactions_count', [enrich_transactions_task, enrich_traces_task])
+    # verify_traces_transactions_count_task = add_verify_tasks(
+        # 'traces_transactions_count', [enrich_transactions_task, enrich_traces_task])
     verify_traces_contracts_count_task = add_verify_tasks(
         'traces_contracts_count', [enrich_transactions_task, enrich_traces_task, enrich_contracts_task])
 
@@ -327,7 +327,7 @@ def build_load_dag(
         verify_logs_count_task,
         verify_token_transfers_have_latest_task,
         verify_traces_blocks_count_task,
-        verify_traces_transactions_count_task,
+        # verify_traces_transactions_count_task,
         verify_traces_contracts_count_task,
         enrich_tokens_task,
         calculate_balances_task,


### PR DESCRIPTION
```
[2025-07-05, 09:49:31 UTC] {taskinstance.py:1084} INFO - Dependencies all met for <TaskInstance: ethereum_load_dag.verify_traces_transactions_count scheduled__2025-07-04T08:30:00+00:00 [queued]>
[2025-07-05, 09:49:31 UTC] {taskinstance.py:1084} INFO - Dependencies all met for <TaskInstance: ethereum_load_dag.verify_traces_transactions_count scheduled__2025-07-04T08:30:00+00:00 [queued]>
[2025-07-05, 09:49:31 UTC] {taskinstance.py:1280} INFO - 
--------------------------------------------------------------------------------
[2025-07-05, 09:49:31 UTC] {taskinstance.py:1281} INFO - Starting attempt 6 of 6
[2025-07-05, 09:49:31 UTC] {taskinstance.py:1282} INFO - 
--------------------------------------------------------------------------------
[2025-07-05, 09:49:31 UTC] {taskinstance.py:1301} INFO - Executing <Task(BigQueryInsertJobOperator): verify_traces_transactions_count> on 2025-07-04 08:30:00+00:00
[2025-07-05, 09:49:31 UTC] {standard_task_runner.py:55} INFO - Started process 141142 to run task
[2025-07-05, 09:49:31 UTC] {standard_task_runner.py:82} INFO - Running: ['airflow', 'tasks', 'run', 'ethereum_load_dag', 'verify_traces_transactions_count', 'scheduled__2025-07-04T08:30:00+00:00', '--job-id', '3432315', '--raw', '--subdir', 'DAGS_FOLDER/ethereum_load_dag.py', '--cfg-path', '/tmp/tmp1b0mi7gl']
[2025-07-05, 09:49:32 UTC] {standard_task_runner.py:83} INFO - Job 3432315: Subtask verify_traces_transactions_count
[2025-07-05, 09:49:32 UTC] {task_command.py:392} INFO - Running <TaskInstance: ethereum_load_dag.verify_traces_transactions_count scheduled__2025-07-04T08:30:00+00:00 [running]> on host airflow-worker-snwkk
[2025-07-05, 09:49:32 UTC] {taskinstance.py:1509} INFO - Exporting the following env vars:
AIRFLOW_CTX_DAG_EMAIL=medvedev1088@gmail.com
AIRFLOW_CTX_DAG_OWNER=airflow
AIRFLOW_CTX_DAG_ID=ethereum_load_dag
AIRFLOW_CTX_TASK_ID=verify_traces_transactions_count
AIRFLOW_CTX_EXECUTION_DATE=2025-07-04T08:30:00+00:00
AIRFLOW_CTX_TRY_NUMBER=6
AIRFLOW_CTX_DAG_RUN_ID=scheduled__2025-07-04T08:30:00+00:00
[2025-07-05, 09:49:32 UTC] {base.py:73} INFO - Using connection ID 'google_cloud_default' for task execution.
[2025-07-05, 09:49:32 UTC] {bigquery.py:2691} INFO - Executing: {'query': {'query': "select if(\n(\nselect count(transaction_hash)\nfrom `bigquery-public-data.crypto_ethereum.traces`\nwhere trace_address is null and transaction_hash is not null\n    and date(block_timestamp) <= '2025-07-04'\n) =\n(\nselect count(*)\nfrom `bigquery-public-data.crypto_ethereum.transactions`\nwhere date(block_timestamp) <= '2025-07-04'\n), 1,\ncast((select 'Total number of traces with null address is not equal to transaction count on 2025-07-04') as int64))", 'useLegacySql': False}}'
[2025-07-05, 09:49:32 UTC] {credentials_provider.py:323} INFO - Getting connection using `google.auth.default()` since no key file is defined for hook.
[2025-07-05, 09:49:32 UTC] {bigquery.py:1546} INFO - Inserting job airflow_ethereum_load_dag_verify_traces_transactions_count_2025_07_04T08_30_00_00_00_66151fc41f41a9bb78dbb3b828e0aa56
[2025-07-05, 09:49:45 UTC] {taskinstance.py:1770} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/opt/python3.8/lib/python3.8/site-packages/airflow/providers/google/cloud/operators/bigquery.py", line 2742, in execute
    job.result(timeout=self.result_timeout, retry=self.result_retry)
  File "/opt/python3.8/lib/python3.8/site-packages/google/cloud/bigquery/job/query.py", line 1499, in result
    do_get_result()
  File "/opt/python3.8/lib/python3.8/site-packages/google/cloud/bigquery/job/query.py", line 1489, in do_get_result
    super(QueryJob, self).result(retry=retry, timeout=timeout)
  File "/opt/python3.8/lib/python3.8/site-packages/google/cloud/bigquery/job/base.py", line 728, in result
    return super(_AsyncJob, self).result(timeout=timeout, **kwargs)
  File "/opt/python3.8/lib/python3.8/site-packages/google/api_core/future/polling.py", line 137, in result
    raise self._exception
google.api_core.exceptions.BadRequest: 400 Bad int64 value: Total number of traces with null...

Location: US
Job ID: airflow_ethereum_load_dag_verify_traces_transactions_count_2025_07_04T08_30_00_00_00_66151fc41f41a9bb78dbb3b828e0aa56

[2025-07-05, 09:49:46 UTC] {taskinstance.py:1319} INFO - Marking task as FAILED. dag_id=ethereum_load_dag, task_id=verify_traces_transactions_count, execution_date=20250704T083000, start_date=20250705T094931, end_date=20250705T094946
[2025-07-05, 09:49:46 UTC] {warnings.py:109} WARNING - /opt/python3.8/lib/python3.8/site-packages/airflow/providers/sendgrid/utils/emailer.py:123: DeprecationWarning: Fetching Sendgrid credentials from environment variables will be deprecated in a future release. Please set credentials using a connection instead.
  _post_sendgrid_mail(mail.get(), conn_id)

[2025-07-05, 09:49:46 UTC] {emailer.py:145} INFO - Email with subject Airflow alert: <TaskInstance: ethereum_load_dag.verify_traces_transactions_count scheduled__2025-07-04T08:30:00+00:00 [failed]> is successfully sent to recipients: [{'to': [{'email': 'medvedev1088@gmail.com'}]}]
[2025-07-05, 09:49:46 UTC] {standard_task_runner.py:100} ERROR - Failed to execute job 3432315 for task verify_traces_transactions_count (400 Bad int64 value: Total number of traces with null...

Location: US
Job ID: airflow_ethereum_load_dag_verify_traces_transactions_count_2025_07_04T08_30_00_00_00_66151fc41f41a9bb78dbb3b828e0aa56
; 141142)
[2025-07-05, 09:49:46 UTC] {local_task_job.py:208} INFO - Task exited with return code 1
[2025-07-05, 09:49:46 UTC] {taskinstance.py:2581} INFO - 0 downstream tasks scheduled from follow-on schedule check
```

Failing SQL:

```
select if(
(
select count(transaction_hash)
from `bigquery-public-data.crypto_ethereum.traces`
where trace_address is null and transaction_hash is not null
    and date(block_timestamp) <= '2025-07-04'
) =
(
select count(*)
from `bigquery-public-data.crypto_ethereum.transactions`
where date(block_timestamp) <= '2025-07-04'
), 1,
cast((select 'Total number of traces with null address is not equal to transaction count on 2025-07-03') as int64))
```